### PR TITLE
Fix browse-track artist navigation

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
@@ -245,7 +245,7 @@ object AppReducer {
         val track = state.library.byId[screen.trackId] ?: return Reduction(state)
         return when {
             key.startsWith("track_album:") -> push(state, Screen.AlbumSongs(track.displayAlbum, track.albumArtistName))
-            key.startsWith("track_artist:") -> push(state, Screen.ArtistSongs(track.primaryArtist))
+            key.startsWith("track_artist:") -> push(state, Screen.ArtistAlbums(track.primaryArtist))
             else -> Reduction(state)
         }
     }

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerNowPlayingTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerNowPlayingTest.kt
@@ -5,6 +5,7 @@ import com.schulzcode.y2player.core.model.PlaybackSnapshot
 import com.schulzcode.y2player.core.model.RepeatMode
 import com.schulzcode.y2player.core.model.Track
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -136,7 +137,7 @@ class AppReducerNowPlayingTest {
         assertEquals(Screen.AddToPlaylist(1), optionsReductionFor("np_playlist:1").state.currentScreen)
     }
 
-    @Test fun optionsMenuGroupsTrackNavigationUnderTrackOptions() {
+    @Test fun trackBrowsePreservesAlbumNavigationAndOpensTheArtistsAlbums() {
         val trackOptions = optionsReductionFor("np_track_options:1").state
         assertEquals(Screen.TrackOptions(1, fromNowPlaying = true), trackOptions.currentScreen)
         assertEquals(
@@ -159,7 +160,9 @@ class AppReducerNowPlayingTest {
         val artistSelected = browse.copy(
             screenStack = browse.screenStack.dropLast(1) + browse.currentEntry.copy(selectedIndex = 1)
         )
-        assertEquals(Screen.ArtistSongs("Artist"), AppReducer.reduce(artistSelected, AppAction.Confirm).state.currentScreen)
+        val artistDestination = AppReducer.reduce(artistSelected, AppAction.Confirm).state.currentScreen
+        assertEquals(Screen.ArtistAlbums("Artist"), artistDestination)
+        assertFalse(artistDestination is Screen.ArtistSongs)
     }
 
     @Test fun queueOpensTheLinearQueueDirectlyWithActionsVisible() {

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/FeaturedArtistTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/FeaturedArtistTest.kt
@@ -253,7 +253,7 @@ class FeaturedArtistTest {
             library = LibraryState(tracks = ram)
         )
         val result = AppReducer.reduce(browse, AppAction.Confirm).state
-        assertEquals(Screen.ArtistSongs("Daft Punk"), result.currentScreen)
+        assertEquals(Screen.ArtistAlbums("Daft Punk"), result.currentScreen)
         assertTrue("the artist screen must not be empty", ScreenContent.rows(result).isNotEmpty())
     }
 


### PR DESCRIPTION
## Summary

Previously, **Track Options → Browse Track → Go to Artist** bypassed the standard artist album view and opened the flat `ArtistSongs` screen. This changes that reducer route to reuse `ArtistAlbums`, matching **Music → Artists** while preserving Go to Album and existing artist normalization.

## Tests

- PASS: `testDebugUnitTest` for `AppReducerNowPlayingTest`, `AppReducerTest`, and `FeaturedArtistTest`
- PASS: full `testDebugUnitTest` suite (876 tests)

Fixes #76