### PR TITLE
Merge completed artwork, queue, and sleep timer fixes

### DIFF
--- a/app/src/main/c/y2audio.c
+++ b/app/src/main/c/y2audio.c
@@ -2097,7 +2097,8 @@ static jbyteArray native_read_artwork(
     if (metadata_probe_open(&probe, native_path, maximum_bytes) == 0) {
         y2_crash_stage = Y2_CRASH_STAGE_READ_ARTWORK;
         artwork = metadata_artwork_stream(probe.format, 1);
-        if (artwork != NULL && artwork->attached_pic.size <= maximum_bytes) {
+        if (artwork != NULL && artwork->attached_pic.size > 0 &&
+            artwork->attached_pic.size <= maximum_bytes) {
             result = (*env)->NewByteArray(env, artwork->attached_pic.size);
             if (result != NULL) {
                 (*env)->SetByteArrayRegion(
@@ -2107,6 +2108,13 @@ static jbyteArray native_read_artwork(
                     artwork->attached_pic.size,
                     (const jbyte *) artwork->attached_pic.data
                 );
+            }
+            if ((*env)->ExceptionCheck(env)) {
+                (*env)->ExceptionClear(env);
+                if (result != NULL) {
+                    (*env)->DeleteLocalRef(env, result);
+                    result = NULL;
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/model/PlaybackModels.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/model/PlaybackModels.kt
@@ -142,6 +142,7 @@ data class PlaybackSnapshot(
     val pauseReason: PauseReason = PauseReason.NONE,
     val errorMessage: String? = null,
     val sleepTimerMode: SleepTimerMode = SleepTimerMode.OFF,
+    val sleepTimerDeadlineElapsedMs: Long? = null,
     val sleepTimerRemainingMs: Long? = null,
     val outputRoute: AudioOutputRoute = AudioOutputRoute.UNKNOWN,
     val audioEffects: AudioEffectsState = AudioEffectsState(),

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
@@ -130,10 +130,9 @@ object AppReducer {
             Screen.QueueManagement -> confirmQueueManagement(state, row)
             Screen.Queue -> when (row) {
                 is Action -> if (row.key == "queue_actions") push(state, Screen.QueueManagement) else Reduction(state)
-                is TrackRow -> row.queueEntry?.let { push(state, Screen.QueueOptions(it.id)) } ?: Reduction(state)
-                is Group -> row.key.takeIf { it.startsWith("queue_missing:") }
-                    ?.substringAfter(':')?.toLongOrNull()?.let { push(state, Screen.QueueOptions(it)) }
+                is TrackRow -> row.queueEntry?.let { playQueueEntryNow(state, it.id, it.trackId) }
                     ?: Reduction(state)
+                is Group -> openQueueEntryOptions(state, row)
                 else -> Reduction(state)
             }
             Screen.NowPlayingOptions -> confirmNowPlayingOptions(state, row)
@@ -745,11 +744,6 @@ object AppReducer {
     private fun confirmLong(state: AppState): Reduction = when {
         state.currentScreen == Screen.NowPlaying -> push(state, Screen.NowPlayingOptions)
         state.currentScreen.isRadialMenu() -> back(state)
-        state.currentScreen == Screen.Queue -> {
-            val entry = (ScreenContent.rows(state).getOrNull(state.selectedIndex) as? TrackRow)?.queueEntry
-                ?: return Reduction(state)
-            playQueueEntryNow(state, entry.id, entry.trackId)
-        }
         state.currentScreen == Screen.EqualizerBands ->
             Reduction(state, listOf(AdjustEqualizerBand(state.selectedIndex, -1)))
         state.currentScreen is Screen.MultiSelect -> {
@@ -882,6 +876,16 @@ object AppReducer {
             val row = ScreenContent.rows(state).getOrNull(state.selectedIndex) as? TrackRow
             if (row == null) Reduction(state) else push(state, Screen.TrackOptions(row.track.id, screen.playlistId))
         }
+        Screen.Queue -> ScreenContent.rows(state).getOrNull(state.selectedIndex)
+            ?.let { openQueueEntryOptions(state, it) } ?: Reduction(state)
+        else -> Reduction(state)
+    }
+
+    private fun openQueueEntryOptions(state: AppState, row: ScreenRow): Reduction = when (row) {
+        is TrackRow -> row.queueEntry?.let { push(state, Screen.QueueOptions(it.id)) } ?: Reduction(state)
+        is Group -> row.key.takeIf { it.startsWith("queue_missing:") }
+            ?.substringAfter(':')?.toLongOrNull()?.let { push(state, Screen.QueueOptions(it)) }
+            ?: Reduction(state)
         else -> Reduction(state)
     }
 

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/ScreenContent.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/ScreenContent.kt
@@ -1454,13 +1454,8 @@ object ScreenContent {
     private fun millisecondsLabel(value: Int): String = if (value <= 0) "Off" else if (value < 1_000) "${value} ms" else "${value / 1_000} seconds"
     private fun secondsLabel(value: Int): String = "${value / 1_000} seconds"
     private fun thresholdLabel(value: Int): String = if (value <= 0) "Always previous" else "After ${value / 1_000} seconds"
-    private fun sleepTimerLabel(state: AppState): String {
-        val mode = state.playback.sleepTimerMode
-        val remaining = state.playback.sleepTimerRemainingMs
-        return if (remaining != null && remaining > 0) "${mode.label} · ${duration(remaining)} left" else mode.label
-    }
     private fun sleepTimerSubtitle(state: AppState): String =
-        "${sleepTimerLabel(state)} · Stops playback after the selected time"
+        SleepTimerPresentation.label(state.playback.sleepTimerMode, state.playback.sleepTimerRemainingMs)
     private fun volumeModeLabel(state: AppState): String = when (state.preferences.volumeMode) {
         VolumeMode.SYSTEM -> "System · hardware keys"
         VolumeMode.PERCEPTUAL -> "In-app · ${VolumeCurve.percentForLevel(state.preferences.volumeLevel)}%"

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/SleepTimerPresentation.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/SleepTimerPresentation.kt
@@ -1,0 +1,28 @@
+package com.schulzcode.y2player.core.state
+
+import com.schulzcode.y2player.core.model.PlaybackSnapshot
+import com.schulzcode.y2player.core.model.SleepTimerMode
+
+internal object SleepTimerPresentation {
+    fun remainingMs(playback: PlaybackSnapshot, nowElapsedMs: Long): Long? =
+        playback.sleepTimerDeadlineElapsedMs
+            ?.let { (it - nowElapsedMs).coerceAtLeast(0L) }
+            ?: playback.sleepTimerRemainingMs?.coerceAtLeast(0L)
+
+    fun countdown(remainingMs: Long): String {
+        val value = remainingMs.coerceAtLeast(0L)
+        val seconds = value / 1_000L + if (value % 1_000L == 0L) 0L else 1L
+        return "${seconds / 60L}:${(seconds % 60L).toString().padStart(2, '0')}"
+    }
+
+    fun label(mode: SleepTimerMode, remainingMs: Long?): String =
+        if (mode.durationMs != null && remainingMs != null) countdown(remainingMs) else mode.label
+
+    fun shouldRefresh(
+        screen: Screen,
+        mode: SleepTimerMode,
+        deadlineElapsedMs: Long?,
+        uiVisible: Boolean
+    ): Boolean = uiVisible && screen == Screen.NowPlayingOptions &&
+        mode.durationMs != null && deadlineElapsedMs != null
+}

--- a/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackService.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackService.kt
@@ -309,11 +309,9 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
             source = "fallback"
         )
     }
-    private var sleepTimerMode = SleepTimerMode.OFF
+    private val sleepTimer = SleepTimerController()
     private var backupImportInProgress = false
-    private var sleepTimerDeadlineElapsed: Long? = null
     private var sleepTimerCallback: Runnable? = null
-    private val sleepTimerGeneration = GenerationGuard()
     private val safetyPolicy = PlaybackSafetyPolicy()
 
     private val storageListener = StorageMonitor.Listener { device ->
@@ -658,7 +656,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
         cancelNextWatchdog(promotedRequestId)
         releaseCurrentTrack(PlaybackExitReason.COMPLETED)
 
-        val advanced = when (sleepTimerMode) {
+        val advanced = when (sleepTimer.mode) {
             SleepTimerMode.END_ALBUM, SleepTimerMode.END_QUEUE -> queue.nextInCurrentPass()
             else -> queue.next()
         }
@@ -1170,9 +1168,9 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
         ) {
             return true
         }
-        val currentPassOnly = !userInitiated && sleepTimerMode in PASS_BOUNDED_SLEEP_MODES
+        val currentPassOnly = !userInitiated && sleepTimer.mode in PASS_BOUNDED_SLEEP_MODES
         if (!moveToNextAvailable(ignoreRepeatOne = userInitiated, currentPassOnly = currentPassOnly)) {
-            finishQueue(endedBySleepTimer = sleepTimerMode in PASS_BOUNDED_SLEEP_MODES)
+            finishQueue(endedBySleepTimer = sleepTimer.mode in PASS_BOUNDED_SLEEP_MODES)
             return snapshot != before
         }
         currentRetryCount = 0
@@ -1253,7 +1251,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
         queue.clear()
         currentTrack = null
         pendingPositionMs = 0
-        snapshot = PlaybackSnapshot(audioEffects = audioEffectsState, sleepTimerMode = sleepTimerMode)
+        snapshot = PlaybackSnapshot(audioEffects = audioEffectsState, sleepTimerMode = sleepTimer.mode)
         playbackHandler.removeCallbacks(queuePersistRunnable)
         queuePersistScheduled = false
         flushQueuePersist()
@@ -1335,7 +1333,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
         scheduleCurrentWatchdog(activeRequestId)
     }
 
-    private fun expectedNextTrackId(): Long? = when (sleepTimerMode) {
+    private fun expectedNextTrackId(): Long? = when (sleepTimer.mode) {
         SleepTimerMode.END_TRACK -> null
         SleepTimerMode.END_ALBUM, SleepTimerMode.END_QUEUE -> queue.peekNextInCurrentPass()
         else -> queue.peekNext()
@@ -1677,7 +1675,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
             status = PlaybackStatus.PAUSED,
             pauseReason = PauseReason.SAFE_MODE,
             audioEffects = audioEffectsState,
-            sleepTimerMode = sleepTimerMode
+            sleepTimerMode = sleepTimer.mode
         )
         publishSnapshot()
     }
@@ -1749,21 +1747,24 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
     }
 
     private fun cycleSleepTimerInternal() {
-        sleepTimerMode = sleepTimerMode.next()
-        sleepTimerDeadlineElapsed = sleepTimerMode.durationMs?.let { SystemClock.elapsedRealtime() + it }
         sleepTimerCallback?.let(playbackHandler::removeCallbacks)
-        val generation = sleepTimerGeneration.advance()
-        sleepTimerDeadlineElapsed?.let { deadline ->
-            val callback = Runnable {
-                if (sleepTimerGeneration.isCurrent(generation) && sleepTimerDeadlineElapsed != null &&
-                    SystemClock.elapsedRealtime() >= sleepTimerDeadlineElapsed!!
-                ) {
-                    clearSleepTimer()
-                    pauseInternal(PauseReason.SLEEP_TIMER)
+        sleepTimerCallback = null
+        sleepTimer.cycle(SystemClock.elapsedRealtime())?.let { scheduled ->
+            val callback = object : Runnable {
+                override fun run() {
+                    when (val tick = sleepTimer.onTimer(scheduled.generation, SystemClock.elapsedRealtime())) {
+                        SleepTimerTick.Expired -> {
+                            sleepTimerCallback = null
+                            syncSleepTimerSnapshot()
+                            pauseInternal(PauseReason.SLEEP_TIMER)
+                        }
+                        is SleepTimerTick.Waiting -> playbackHandler.postDelayed(this, tick.delayMs)
+                        SleepTimerTick.Stale -> Unit
+                    }
                 }
             }
             sleepTimerCallback = callback
-            playbackHandler.postDelayed(callback, (deadline - SystemClock.elapsedRealtime()).coerceAtLeast(1))
+            playbackHandler.postDelayed(callback, scheduled.delayMs)
         }
         revalidatePreload()
         refreshSnapshot()
@@ -1771,14 +1772,17 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
     }
 
     private fun clearSleepTimer() {
-        sleepTimerGeneration.advance()
-        sleepTimerMode = SleepTimerMode.OFF
-        sleepTimerDeadlineElapsed = null
+        sleepTimer.clear()
         sleepTimerCallback?.let { if (::playbackHandler.isInitialized) playbackHandler.removeCallbacks(it) }
         sleepTimerCallback = null
+        syncSleepTimerSnapshot()
     }
 
-    private fun shouldStopAfterCurrentTrack(): Boolean = when (sleepTimerMode) {
+    private fun syncSleepTimerSnapshot() {
+        snapshot = sleepTimer.applyTo(snapshot, SystemClock.elapsedRealtime())
+    }
+
+    private fun shouldStopAfterCurrentTrack(): Boolean = when (sleepTimer.mode) {
         SleepTimerMode.END_TRACK -> true
         SleepTimerMode.END_ALBUM -> queue.peekNextInCurrentPass()
             ?.let(libraryRepository::findTrack)
@@ -1787,7 +1791,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
         else -> false
     }
 
-    private fun shouldStopBefore(nextTrack: Track): Boolean = when (sleepTimerMode) {
+    private fun shouldStopBefore(nextTrack: Track): Boolean = when (sleepTimer.mode) {
         SleepTimerMode.END_TRACK -> true
         SleepTimerMode.END_ALBUM -> albumKey(currentTrack) != albumKey(nextTrack)
         else -> false
@@ -2114,7 +2118,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
         errorMessage: String? = null
     ): PlaybackSnapshot {
         val queueState = queue.snapshot()
-        val remaining = sleepTimerDeadlineElapsed?.let { (it - SystemClock.elapsedRealtime()).coerceAtLeast(0) }
+        val remaining = sleepTimer.deadlineElapsedMs?.let { (it - SystemClock.elapsedRealtime()).coerceAtLeast(0) }
         val routes = if (::routeMonitor.isInitialized) routeMonitor.snapshot() else PrivateRouteSnapshot()
         return PlaybackSnapshot(
             status = status,
@@ -2128,7 +2132,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
             shuffleEnabled = queueState.shuffleEnabled,
             pauseReason = pauseReason,
             errorMessage = errorMessage,
-            sleepTimerMode = sleepTimerMode,
+            sleepTimerMode = sleepTimer.mode,
             sleepTimerRemainingMs = remaining,
             outputRoute = AudioOutputRouteResolver.resolve(
                 wired = routes.wired,
@@ -2203,7 +2207,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
             durationMs = duration.coerceAtLeast(0),
             pauseReason = PauseReason.NONE,
             errorMessage = null,
-            sleepTimerRemainingMs = sleepTimerDeadlineElapsed
+            sleepTimerRemainingMs = sleepTimer.deadlineElapsedMs
                 ?.let { (it - SystemClock.elapsedRealtime()).coerceAtLeast(0) }
         )
     }

--- a/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackService.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackService.kt
@@ -2133,6 +2133,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
             pauseReason = pauseReason,
             errorMessage = errorMessage,
             sleepTimerMode = sleepTimer.mode,
+            sleepTimerDeadlineElapsedMs = sleepTimer.deadlineElapsedMs,
             sleepTimerRemainingMs = remaining,
             outputRoute = AudioOutputRouteResolver.resolve(
                 wired = routes.wired,
@@ -2206,9 +2207,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
             positionMs = position.coerceAtLeast(0),
             durationMs = duration.coerceAtLeast(0),
             pauseReason = PauseReason.NONE,
-            errorMessage = null,
-            sleepTimerRemainingMs = sleepTimer.deadlineElapsedMs
-                ?.let { (it - SystemClock.elapsedRealtime()).coerceAtLeast(0) }
+            errorMessage = null
         )
     }
 

--- a/app/src/main/kotlin/com/schulzcode/y2player/playback/SleepTimerController.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/playback/SleepTimerController.kt
@@ -48,6 +48,7 @@ internal class SleepTimerController {
 
     fun applyTo(snapshot: PlaybackSnapshot, nowElapsedMs: Long): PlaybackSnapshot = snapshot.copy(
         sleepTimerMode = mode,
+        sleepTimerDeadlineElapsedMs = deadlineElapsedMs,
         sleepTimerRemainingMs = deadlineElapsedMs?.let { (it - nowElapsedMs).coerceAtLeast(0L) }
     )
 }

--- a/app/src/main/kotlin/com/schulzcode/y2player/playback/SleepTimerController.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/playback/SleepTimerController.kt
@@ -1,0 +1,53 @@
+package com.schulzcode.y2player.playback
+
+import com.schulzcode.y2player.core.model.PlaybackSnapshot
+import com.schulzcode.y2player.core.model.SleepTimerMode
+
+internal data class ScheduledSleepTimer(
+    val generation: Long,
+    val delayMs: Long
+)
+
+internal sealed class SleepTimerTick {
+    data class Waiting(val delayMs: Long) : SleepTimerTick()
+    object Expired : SleepTimerTick()
+    object Stale : SleepTimerTick()
+}
+
+internal class SleepTimerController {
+    private val generation = GenerationGuard()
+
+    var mode: SleepTimerMode = SleepTimerMode.OFF
+        private set
+    var deadlineElapsedMs: Long? = null
+        private set
+
+    fun cycle(nowElapsedMs: Long): ScheduledSleepTimer? {
+        mode = mode.next()
+        deadlineElapsedMs = mode.durationMs?.let { nowElapsedMs + it }
+        val value = generation.advance()
+        return deadlineElapsedMs?.let { deadline ->
+            ScheduledSleepTimer(value, (deadline - nowElapsedMs).coerceAtLeast(1L))
+        }
+    }
+
+    fun onTimer(generationValue: Long, nowElapsedMs: Long): SleepTimerTick {
+        if (!generation.isCurrent(generationValue)) return SleepTimerTick.Stale
+        val deadline = deadlineElapsedMs ?: return SleepTimerTick.Stale
+        val remaining = deadline - nowElapsedMs
+        if (remaining > 0L) return SleepTimerTick.Waiting(remaining)
+        clear()
+        return SleepTimerTick.Expired
+    }
+
+    fun clear() {
+        generation.advance()
+        mode = SleepTimerMode.OFF
+        deadlineElapsedMs = null
+    }
+
+    fun applyTo(snapshot: PlaybackSnapshot, nowElapsedMs: Long): PlaybackSnapshot = snapshot.copy(
+        sleepTimerMode = mode,
+        sleepTimerRemainingMs = deadlineElapsedMs?.let { (it - nowElapsedMs).coerceAtLeast(0L) }
+    )
+}

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
@@ -23,6 +23,7 @@ import com.schulzcode.y2player.core.state.AppState
 import com.schulzcode.y2player.core.state.Screen
 import com.schulzcode.y2player.core.state.ScreenContent
 import com.schulzcode.y2player.core.state.ScreenRow
+import com.schulzcode.y2player.core.state.SleepTimerPresentation
 import com.schulzcode.y2player.core.state.isRadialMenu
 import com.schulzcode.y2player.core.state.isProgressOnlyUpdate
 import com.schulzcode.y2player.util.TimeFormat
@@ -70,6 +71,15 @@ class Y2PlayerView(
             scheduleTextScroll(delay)
         }
     }
+    private var sleepTimerCountdownCallbackScheduled = false
+    private val sleepTimerCountdownRunnable = object : Runnable {
+        override fun run() {
+            sleepTimerCountdownCallbackScheduled = false
+            if (!shouldRefreshSleepTimerCountdown()) return
+            refreshSleepTimerCountdownRows()
+            updateSleepTimerCountdownActivity(refreshRows = false)
+        }
+    }
 
     private var state: AppState = AppState()
 
@@ -81,7 +91,7 @@ class Y2PlayerView(
         palette = next
         return true
     }
-    private var rows = ScreenContent.rows(state)
+    private var rows = rowsForState(state)
     private var artwork: Bitmap? = null
     private var artworkPath: String? = null
     private var artworkIdentity: Triple<Long, Long, Long>? = null
@@ -177,6 +187,7 @@ class Y2PlayerView(
         if (textAnimationsVisible == visible) return
         textAnimationsVisible = visible
         updateTextScrollActivity()
+        updateSleepTimerCountdownActivity()
     }
 
     fun onNavigationInput() {
@@ -201,6 +212,7 @@ class Y2PlayerView(
         super.onAttachedToWindow()
         attached = true
         updateTextScrollActivity()
+        updateSleepTimerCountdownActivity()
         requestVisibleRowArtworks()
     }
 
@@ -208,6 +220,7 @@ class Y2PlayerView(
         attached = false
         cancelVisibleRowArtworkRequests()
         stopTextScrollCallbacks()
+        stopSleepTimerCountdownCallback()
         setTextScrollersActive(false, SystemClock.uptimeMillis())
         super.onDetachedFromWindow()
     }
@@ -215,12 +228,14 @@ class Y2PlayerView(
     override fun onWindowVisibilityChanged(visibility: Int) {
         super.onWindowVisibilityChanged(visibility)
         updateTextScrollActivity()
+        updateSleepTimerCountdownActivity()
         if (visibility == VISIBLE) requestVisibleRowArtworks() else cancelVisibleRowArtworkRequests()
     }
 
     override fun onVisibilityChanged(changedView: View, visibility: Int) {
         super.onVisibilityChanged(changedView, visibility)
         updateTextScrollActivity()
+        updateSleepTimerCountdownActivity()
         if (visibility == VISIBLE) requestVisibleRowArtworks() else cancelVisibleRowArtworkRequests()
     }
 
@@ -232,7 +247,7 @@ class Y2PlayerView(
             !newState.currentScreen.isRadialMenu()
         if (closingRadial) {
             closingRadialState = oldState
-            closingRadialRows = ScreenContent.rows(oldState)
+            closingRadialRows = rowsForState(oldState)
         }
         when {
             openingRadial -> startRadialAnimation(opening = true)
@@ -247,6 +262,7 @@ class Y2PlayerView(
             oldState.copy(screenStack = newState.screenStack) == newState
 
         state = newState
+        updateSleepTimerCountdownActivity(refreshRows = false)
         if (selectionOnly) {
             if (ensureSelectionVisible()) requestVisibleRowArtworks()
             updateFooterPosition()
@@ -266,7 +282,7 @@ class Y2PlayerView(
                 }
                 Screen.NowPlayingOptions, Screen.QueueManagement, is Screen.QueueOptions -> {
                     if (oldState.playback.sleepTimerRemainingMs != newState.playback.sleepTimerRemainingMs) {
-                        rows = ScreenContent.rows(newState)
+                        rows = rowsForState(newState)
                         invalidateRowCache()
                     }
                     invalidate()
@@ -278,7 +294,7 @@ class Y2PlayerView(
             return
         }
 
-        rows = ScreenContent.rows(newState)
+        rows = rowsForState(newState)
         requestArtwork()
         updatePresentationCache()
         invalidateRowCache()
@@ -310,6 +326,7 @@ class Y2PlayerView(
         detailArtwork = null
         detailArtworkPath = null
         cancelVisibleRowArtworkRequests()
+        stopSleepTimerCountdownCallback()
         radialAnimationActive = false
         closingRadialState = null
         closingRadialRows = emptyList()
@@ -330,6 +347,52 @@ class Y2PlayerView(
         stopTextScrollCallbacks()
         if (active) rescheduleTextScroll()
         if (changed) invalidateTextScrollTarget()
+    }
+
+    private fun rowsForState(value: AppState): List<ScreenRow> {
+        if (value.currentScreen != Screen.NowPlayingOptions) return ScreenContent.rows(value)
+        val remaining = SleepTimerPresentation.remainingMs(value.playback, SystemClock.elapsedRealtime())
+            ?: return ScreenContent.rows(value)
+        return ScreenContent.rows(value.copy(
+            playback = value.playback.copy(sleepTimerRemainingMs = remaining)
+        ))
+    }
+
+    private fun shouldRefreshSleepTimerCountdown(): Boolean {
+        val uiVisible = attached && textAnimationsVisible &&
+            windowVisibility == VISIBLE && visibility == VISIBLE
+        return SleepTimerPresentation.shouldRefresh(
+            state.currentScreen,
+            state.playback.sleepTimerMode,
+            state.playback.sleepTimerDeadlineElapsedMs,
+            uiVisible
+        )
+    }
+
+    private fun updateSleepTimerCountdownActivity(refreshRows: Boolean = true) {
+        if (!shouldRefreshSleepTimerCountdown()) {
+            stopSleepTimerCountdownCallback()
+            return
+        }
+        if (refreshRows) refreshSleepTimerCountdownRows()
+        if (sleepTimerCountdownCallbackScheduled) return
+        sleepTimerCountdownCallbackScheduled = true
+        postDelayed(sleepTimerCountdownRunnable, SLEEP_TIMER_REFRESH_MS)
+    }
+
+    private fun refreshSleepTimerCountdownRows() {
+        val updated = rowsForState(state)
+        if (updated == rows) return
+        rows = updated
+        invalidateRowCache()
+        updateContentDescription(state)
+        invalidate()
+    }
+
+    private fun stopSleepTimerCountdownCallback() {
+        if (!sleepTimerCountdownCallbackScheduled) return
+        removeCallbacks(sleepTimerCountdownRunnable)
+        sleepTimerCountdownCallbackScheduled = false
     }
 
     private fun rescheduleTextScroll() {
@@ -2210,6 +2273,7 @@ class Y2PlayerView(
         private const val SCAN_PROGRESS_PHASE_STEPS = 200
         private const val MARQUEE_SPEED_DP_PER_SECOND = 28f
         private const val MARQUEE_FRAME_MS = 100L
+        private const val SLEEP_TIMER_REFRESH_MS = 1_000L
         private const val ROW_ARTWORK_LEFT_DP = 8f
         private const val ROW_ARTWORK_SIZE_DP = 40f
         private const val ROW_ARTWORK_SIZE_PX = 64

--- a/app/src/test/kotlin/com/schulzcode/y2player/artwork/ArtworkSourceResolverTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/artwork/ArtworkSourceResolverTest.kt
@@ -47,6 +47,39 @@ class ArtworkSourceResolverTest {
         assertNull(resolverWithEmbedded(null).resolve(key(corruptTrack), 256, ::decodeImage))
     }
 
+    @Test fun embeddedArtworkHonorsMaximumByteBoundary() {
+        val track = temporaryFolder.newFile("boundary.mp3")
+        var decodeCount = 0
+        fun resolve(bytes: ByteArray): String? = ArtworkSourceResolver(
+            maximumBytes = 4,
+            readEmbedded = { _, _ -> bytes }
+        ).resolve(key(track), 256) { value, _ ->
+            decodeCount += 1
+            value.toString(Charsets.UTF_8)
+        }
+
+        assertEquals("1234", resolve("1234".toByteArray()))
+        assertNull(resolve("12345".toByteArray()))
+        assertEquals(1, decodeCount)
+    }
+
+    @Test fun embeddedArtworkAllocationAndDecodeFailuresFailSafely() {
+        val track = temporaryFolder.newFile("failure.mp3")
+        val allocationFailure = ArtworkSourceResolver(
+            maximumBytes = 4,
+            readEmbedded = { _, _ -> throw OutOfMemoryError("test") }
+        )
+        val decodeFailure = ArtworkSourceResolver(
+            maximumBytes = 4,
+            readEmbedded = { _, _ -> byteArrayOf(1) }
+        )
+
+        assertNull(allocationFailure.resolve(key(track), 256, ::decodeText))
+        assertNull(decodeFailure.resolve<String>(key(track), 256) { _, _ ->
+            throw OutOfMemoryError("test")
+        })
+    }
+
     @Test fun sourceAndBitmapCacheKeysInvalidateOnlyForRelevantChanges() {
         val folder = temporaryFolder.newFolder("cache")
         val track = File(folder, "song.flac").apply { writeText("audio") }

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerTest.kt
@@ -145,22 +145,22 @@ class AppReducerTest {
         assertEquals(2L, effect.trackIds[effect.startIndex])
     }
 
-    @Test fun confirmingAQueueRowOpensItsCircularActions() {
+    @Test fun shortCenterOnQueueTrackPlaysTheSelectedEntry() {
         val second = track.copy(id = 2, title = "Second")
         val state = AppState(
             screenStack = listOf(ScreenEntry(Screen.Queue, selectedIndex = 2)),
             library = LibraryState(tracks = listOf(track, second)),
             playback = PlaybackSnapshot(
                 status = PlaybackStatus.PLAYING,
-                currentTrackId = 2L,
+                currentTrackId = 1L,
                 queue = testQueue(1L, 2L),
-                currentQueueEntryId = 2L
+                currentQueueEntryId = 1L
             )
         )
         val result = AppReducer.reduce(state, AppAction.Confirm)
 
-        assertEquals(Screen.QueueOptions(2L), result.state.currentScreen)
-        assertTrue(result.effects.isEmpty())
+        assertEquals(Screen.NowPlaying, result.state.currentScreen)
+        assertEquals(AppEffect.PlayQueueEntry(2L), result.effects.single())
     }
 
     @Test fun confirmingADuplicateQueueRowPlaysThatPosition() {
@@ -174,10 +174,9 @@ class AppReducerTest {
                 currentQueueEntryId = 1L
             )
         )
-        val options = AppReducer.reduce(state, AppAction.Confirm).state
-        assertEquals(Screen.QueueOptions(2L), options.currentScreen)
-        val effect = AppReducer.reduce(selectKey(options, "queue_play:2"), AppAction.Confirm)
-            .effects.single() as AppEffect.PlayQueueEntry
+        val result = AppReducer.reduce(state, AppAction.Confirm)
+        val effect = result.effects.single() as AppEffect.PlayQueueEntry
+        assertEquals(Screen.NowPlaying, result.state.currentScreen)
         assertEquals(2L, effect.entryId)
     }
 
@@ -513,20 +512,21 @@ class AppReducerTest {
         )
     }
 
-    @Test fun longCenterOnQueueIsTheQuickPlayShortcut() {
+    @Test fun longCenterOnQueueOpensOptionsWithoutPlaying() {
+        val second = track.copy(id = 2, title = "Second")
         val state = AppState(
-            screenStack = listOf(ScreenEntry(Screen.Queue, selectedIndex = 1)),
-            library = LibraryState(tracks = listOf(track)),
+            screenStack = listOf(ScreenEntry(Screen.Queue, selectedIndex = 2)),
+            library = LibraryState(tracks = listOf(track, second)),
             playback = com.schulzcode.y2player.core.model.PlaybackSnapshot(
                 status = PlaybackStatus.PLAYING,
                 currentTrackId = 1L,
-                queue = testQueue(1L),
+                queue = testQueue(1L, 2L),
                 currentQueueEntryId = 1L
             )
         )
         val result = AppReducer.reduce(state, AppAction.ConfirmLong)
-        assertEquals(Screen.NowPlaying, result.state.currentScreen)
-        assertTrue(result.effects.isEmpty())
+        assertEquals(Screen.QueueOptions(2L), result.state.currentScreen)
+        assertTrue("long center must not also play the queue entry", result.effects.isEmpty())
     }
 
     @Test fun destructiveQueueActionsLiveUnderQueueManagement() {
@@ -548,6 +548,9 @@ class AppReducerTest {
         )
         val optionKeys = ScreenContent.rows(queueItem).filterIsInstance<ScreenRow.Action>().map { it.key }
         assertEquals(listOf("queue_play:1", "queue_remove:1"), optionKeys)
+        val removed = AppReducer.reduce(selectKey(queueItem, "queue_remove:1"), AppAction.Confirm)
+        assertEquals(Screen.Queue, removed.state.currentScreen)
+        assertEquals(AppEffect.RemoveQueueEntry(1L), removed.effects.single())
 
         val queue = AppReducer.reduce(selectKey(options, "queue"), AppAction.Confirm).state
         assertEquals(Screen.Queue, queue.currentScreen)
@@ -656,7 +659,7 @@ class AppReducerTest {
             playback = com.schulzcode.y2player.core.model.PlaybackSnapshot(queue = testQueue(1L), currentQueueEntryId = 1L)
         )
 
-        val result = AppReducer.reduce(state, AppAction.Confirm).state
+        val result = AppReducer.reduce(state, AppAction.ConfirmLong).state
 
         assertEquals(Screen.QueueOptions(1), result.currentScreen)
         assertEquals(0, result.selectedIndex)
@@ -671,7 +674,7 @@ class AppReducerTest {
             playback = PlaybackSnapshot(queue = testQueue(1L, 2L, 3L), currentQueueEntryId = 1L)
         )
 
-        val options = AppReducer.reduce(state, AppAction.Confirm).state
+        val options = AppReducer.reduce(state, AppAction.ConfirmLong).state
         assertEquals(Screen.QueueOptions(3L), options.currentScreen)
         assertEquals(
             listOf("queue_play:3", "queue_next:3", "queue_move:3", "queue_remove:3"),

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/NavigationCorrectnessTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/NavigationCorrectnessTest.kt
@@ -85,9 +85,7 @@ class NavigationCorrectnessTest {
         )
         val state = AppState(screenStack = stack, library = library, playback = playing)
 
-        val options = AppReducer.reduce(state, AppAction.Confirm).state
-        assertTrue(options.currentScreen is Screen.QueueOptions)
-        val result = AppReducer.reduce(options, AppAction.Confirm).state
+        val result = AppReducer.reduce(state, AppAction.Confirm).state
 
         assertEquals(Screen.NowPlaying, result.currentScreen)
         assertEquals("must unwind, not push", 2, result.screenStack.size)
@@ -102,8 +100,7 @@ class NavigationCorrectnessTest {
             ScreenEntry(Screen.Queue, selectedIndex = 1)
         )
         val state = AppState(screenStack = stack, library = library, playback = playing)
-        val options = AppReducer.reduce(state, AppAction.Confirm).state
-        val nowPlaying = AppReducer.reduce(options, AppAction.Confirm).state
+        val nowPlaying = AppReducer.reduce(state, AppAction.Confirm).state
 
         val back = AppReducer.reduce(nowPlaying, AppAction.Back).state
 

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/ScreenContentTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/ScreenContentTest.kt
@@ -124,7 +124,7 @@ class ScreenContentTest {
         assertEquals("queue_actions", (rows[0] as ScreenRow.Action).key)
         assertTrue("missing id renders as a placeholder, not dropped", rows[1] is ScreenRow.Group)
         assertTrue(rows[2] is ScreenRow.TrackRow)
-        val options = AppReducer.reduce(state, AppAction.Confirm).state
+        val options = AppReducer.reduce(state, AppAction.ConfirmLong).state
         assertEquals(Screen.QueueOptions(2L), options.currentScreen)
         val effect = AppReducer.reduce(options, AppAction.Confirm).effects.single()
         assertEquals(AppEffect.PlayQueueEntry(2L), effect)

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/SleepTimerPresentationTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/SleepTimerPresentationTest.kt
@@ -1,0 +1,89 @@
+package com.schulzcode.y2player.core.state
+
+import com.schulzcode.y2player.core.model.PlaybackSnapshot
+import com.schulzcode.y2player.core.model.SleepTimerMode
+import com.schulzcode.y2player.playback.SleepTimerController
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SleepTimerPresentationTest {
+    @Test fun fifteenMinuteTimerInitiallyDisplaysFifteenMinutes() {
+        val timer = SleepTimerController()
+        timer.cycle(10_000L)
+        val snapshot = timer.applyTo(PlaybackSnapshot(), 10_001L)
+        val remaining = SleepTimerPresentation.remainingMs(snapshot, 10_001L)
+
+        assertEquals(899_999L, remaining)
+        assertEquals("15:00", SleepTimerPresentation.label(snapshot.sleepTimerMode, remaining))
+
+        val state = AppState(
+            screenStack = listOf(ScreenEntry(Screen.NowPlayingOptions)),
+            playback = snapshot.copy(sleepTimerRemainingMs = remaining)
+        )
+        val timerRow = ScreenContent.rows(state)
+            .filterIsInstance<ScreenRow.Action>()
+            .first { it.key == "sleep_timer" }
+        assertEquals("15:00", timerRow.subtitle)
+    }
+
+    @Test fun remainingTimeIsAlwaysDerivedFromTheDeadline() {
+        val snapshot = PlaybackSnapshot(
+            sleepTimerMode = SleepTimerMode.MINUTES_15,
+            sleepTimerDeadlineElapsedMs = 901_000L,
+            sleepTimerRemainingMs = 123L
+        )
+
+        assertEquals(900_000L, SleepTimerPresentation.remainingMs(snapshot, 1_000L))
+        assertEquals(899_000L, SleepTimerPresentation.remainingMs(snapshot, 2_000L))
+        assertEquals(0L, SleepTimerPresentation.remainingMs(snapshot, 999_999L))
+    }
+
+    @Test fun countdownUsesCleanMinutesAndSecondsWithoutEllipsis() {
+        assertEquals("15:00", SleepTimerPresentation.countdown(899_999L))
+        assertEquals("14:59", SleepTimerPresentation.countdown(899_000L))
+        assertEquals("0:01", SleepTimerPresentation.countdown(1L))
+        assertEquals("0:00", SleepTimerPresentation.countdown(0L))
+        assertFalse(SleepTimerPresentation.countdown(899_999L).contains("..."))
+    }
+
+    @Test fun refreshRunsOnlyWhileANumericCountdownIsVisible() {
+        assertTrue(SleepTimerPresentation.shouldRefresh(
+            Screen.NowPlayingOptions,
+            SleepTimerMode.MINUTES_15,
+            deadlineElapsedMs = 900_000L,
+            uiVisible = true
+        ))
+        assertFalse(SleepTimerPresentation.shouldRefresh(
+            Screen.NowPlaying,
+            SleepTimerMode.MINUTES_15,
+            deadlineElapsedMs = 900_000L,
+            uiVisible = true
+        ))
+        assertFalse(SleepTimerPresentation.shouldRefresh(
+            Screen.NowPlayingOptions,
+            SleepTimerMode.END_TRACK,
+            deadlineElapsedMs = null,
+            uiVisible = true
+        ))
+        assertFalse(SleepTimerPresentation.shouldRefresh(
+            Screen.NowPlayingOptions,
+            SleepTimerMode.MINUTES_15,
+            deadlineElapsedMs = 900_000L,
+            uiVisible = false
+        ))
+    }
+
+    @Test fun reopeningAfterExpirationReportsOff() {
+        val state = AppState(
+            screenStack = listOf(ScreenEntry(Screen.NowPlayingOptions)),
+            playback = PlaybackSnapshot(sleepTimerMode = SleepTimerMode.OFF)
+        )
+        val timerRow = ScreenContent.rows(state)
+            .filterIsInstance<ScreenRow.Action>()
+            .first { it.key == "sleep_timer" }
+
+        assertEquals("Off", timerRow.subtitle)
+    }
+}

--- a/app/src/test/kotlin/com/schulzcode/y2player/library/FfmpegMetadataArchitectureTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/library/FfmpegMetadataArchitectureTest.kt
@@ -42,6 +42,22 @@ class FfmpegMetadataArchitectureTest {
         assertTrue(ffmpegPatch.contains("av_buffer_unref(buf)"))
         assertTrue(ffmpegPatch.contains("METADATA_BLOCK_PICTURE"))
         assertTrue(ffmpegPatch.contains("s->skip_attached_picture_payloads"))
+        assertTrue(ffmpegPatch.contains("(!buf && !pb)"))
+        assertTrue(ffmpegPatch.contains("Do not pass it to av_get_packet()"))
+    }
+
+    @Test fun artworkJniRejectsInvalidSizesAndClearsAllocationFailures() {
+        val source = File(repositoryRoot(), "app/src/main/c/y2audio.c").readText()
+        val artworkReader = source.substring(
+            source.indexOf("static jbyteArray native_read_artwork"),
+            source.indexOf("static jint native_error_category")
+        )
+
+        assertTrue(artworkReader.contains("artwork->attached_pic.size > 0"))
+        assertTrue(artworkReader.contains("artwork->attached_pic.size <= maximum_bytes"))
+        assertTrue(artworkReader.contains("ExceptionCheck"))
+        assertTrue(artworkReader.contains("ExceptionClear"))
+        assertTrue(artworkReader.contains("result = NULL"))
     }
 
     @Test fun id3ArtworkProbeCarriesAFormatContextAndGuardsItsUse() {

--- a/app/src/test/kotlin/com/schulzcode/y2player/playback/SleepTimerControllerTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/playback/SleepTimerControllerTest.kt
@@ -1,0 +1,128 @@
+package com.schulzcode.y2player.playback
+
+import com.schulzcode.y2player.core.model.PlaybackSnapshot
+import com.schulzcode.y2player.core.model.SleepTimerMode
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SleepTimerControllerTest {
+    @Test fun activeTimerExpiresBeforeThePlaybackStopPathRuns() {
+        val timer = SleepTimerController()
+        val scheduled = requireNotNull(timer.cycle(1_000L))
+
+        assertEquals(
+            SleepTimerTick.Expired,
+            timer.onTimer(scheduled.generation, 1_000L + requireNotNull(timer.mode.durationMs))
+        )
+        assertEquals(SleepTimerMode.OFF, timer.mode)
+        assertNull(timer.deadlineElapsedMs)
+
+        val source = playbackServiceSource()
+        val expiry = source.substringAfter("SleepTimerTick.Expired ->")
+            .substringBefore("is SleepTimerTick.Waiting")
+        assertTrue(expiry.indexOf("syncSleepTimerSnapshot()") < expiry.indexOf("pauseInternal(PauseReason.SLEEP_TIMER)"))
+    }
+
+    @Test fun expiredTimerIsInactiveInThePublishedSnapshot() {
+        val timer = SleepTimerController()
+        val scheduled = requireNotNull(timer.cycle(0L))
+        val deadline = requireNotNull(timer.deadlineElapsedMs)
+        val active = timer.applyTo(PlaybackSnapshot(), 1L)
+        assertEquals(SleepTimerMode.MINUTES_15, active.sleepTimerMode)
+
+        timer.onTimer(scheduled.generation, deadline)
+        val expired = timer.applyTo(active, deadline)
+
+        assertEquals(SleepTimerMode.OFF, expired.sleepTimerMode)
+        assertNull(expired.sleepTimerRemainingMs)
+    }
+
+    @Test fun manuallyCancelledTimerStaysOffAndCannotBeRestoredByItsCallback() {
+        val timer = SleepTimerController()
+        val cancelled = requireNotNull(timer.cycle(10L))
+
+        repeat(SleepTimerMode.values().size - 1) { timer.cycle(20L + it) }
+
+        assertEquals(SleepTimerMode.OFF, timer.mode)
+        assertNull(timer.deadlineElapsedMs)
+        assertEquals(
+            SleepTimerTick.Stale,
+            timer.onTimer(cancelled.generation, 10L + requireNotNull(SleepTimerMode.MINUTES_15.durationMs))
+        )
+        assertEquals(SleepTimerMode.OFF, timer.mode)
+    }
+
+    @Test fun trackAlbumAndQueueModesRemainBoundaryBasedAndClearAfterStopping() {
+        listOf(SleepTimerMode.END_TRACK, SleepTimerMode.END_ALBUM, SleepTimerMode.END_QUEUE).forEach { target ->
+            val timer = SleepTimerController()
+            var scheduled: ScheduledSleepTimer? = null
+            repeat(target.ordinal) { scheduled = timer.cycle(it.toLong()) }
+
+            assertEquals(target, timer.mode)
+            assertNull(scheduled)
+            assertNull(timer.deadlineElapsedMs)
+
+            timer.clear()
+            assertEquals(SleepTimerMode.OFF, timer.mode)
+        }
+    }
+
+    @Test fun aNewTimerWorksAfterThePreviousTimerExpired() {
+        val timer = SleepTimerController()
+        val first = requireNotNull(timer.cycle(0L))
+        timer.onTimer(first.generation, requireNotNull(timer.mode.durationMs))
+
+        val secondStartedAt = 2_000_000L
+        val second = requireNotNull(timer.cycle(secondStartedAt))
+        assertEquals(SleepTimerMode.MINUTES_15, timer.mode)
+        assertEquals(
+            SleepTimerTick.Expired,
+            timer.onTimer(second.generation, secondStartedAt + requireNotNull(timer.mode.durationMs))
+        )
+        assertEquals(SleepTimerMode.OFF, timer.mode)
+    }
+
+    @Test fun replacingATimerInvalidatesTheOldCallbackAndKeepsTheNewDeadline() {
+        val timer = SleepTimerController()
+        val old = requireNotNull(timer.cycle(0L))
+        val replacementStartedAt = 500L
+        val replacement = requireNotNull(timer.cycle(replacementStartedAt))
+
+        assertEquals(SleepTimerMode.MINUTES_30, timer.mode)
+        assertEquals(SleepTimerTick.Stale, timer.onTimer(old.generation, requireNotNull(SleepTimerMode.MINUTES_15.durationMs)))
+        assertEquals(
+            SleepTimerTick.Expired,
+            timer.onTimer(replacement.generation, replacementStartedAt + requireNotNull(SleepTimerMode.MINUTES_30.durationMs))
+        )
+    }
+
+    @Test fun anEarlyCallbackIsRescheduledInsteadOfLeavingAnElapsedTimerActive() {
+        val timer = SleepTimerController()
+        val scheduled = requireNotNull(timer.cycle(1_000L))
+        val deadline = requireNotNull(timer.deadlineElapsedMs)
+
+        assertEquals(
+            SleepTimerTick.Waiting(1L),
+            timer.onTimer(scheduled.generation, deadline - 1L)
+        )
+        assertEquals(SleepTimerMode.MINUTES_15, timer.mode)
+        assertEquals(SleepTimerTick.Expired, timer.onTimer(scheduled.generation, deadline))
+    }
+
+    private fun playbackServiceSource(): String = File(
+        repositoryRoot(),
+        "app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackService.kt"
+    ).readText()
+
+    private fun repositoryRoot(): File {
+        var directory: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        while (directory != null) {
+            if (File(directory, "app/src/main/AndroidManifest.xml").isFile) return directory
+            directory = directory.parentFile
+        }
+        throw AssertionError("repository root not found")
+    }
+}

--- a/tools/native/patches/0002-skip-attached-picture-payloads.patch
+++ b/tools/native/patches/0002-skip-attached-picture-payloads.patch
@@ -48,16 +48,18 @@ Applies to: ffmpeg-8.1.2
       */
 --- a/libavformat/demux_utils.c
 +++ b/libavformat/demux_utils.c
-@@ -114,6 +114,28 @@ int ff_add_attached_pic(AVFormatContext *s, AVStream *st0, AVIOContext *pb,
+@@ -114,6 +114,30 @@ int ff_add_attached_pic(AVFormatContext *s, AVStream *st0, AVIOContext *pb,
      if (!st && !(st = avformat_new_stream(s, NULL)))
          return AVERROR(ENOMEM);
      pkt = &st->attached_pic;
-+    if (s->skip_attached_picture_payloads ||
++    if (s->skip_attached_picture_payloads || (!buf && !pb) ||
 +        (s->max_attached_picture_payload_size > 0 &&
 +         ((buf && *buf && (*buf)->size > AV_INPUT_BUFFER_PADDING_SIZE &&
 +                         (*buf)->size - AV_INPUT_BUFFER_PADDING_SIZE >
 +                         s->max_attached_picture_payload_size) ||
 +          (!buf && size > s->max_attached_picture_payload_size)))) {
++        /* A NULL buffer and input is the sentinel for an already-skipped
++         * ID3/Vorbis payload. Do not pass it to av_get_packet(). */
 +        av_packet_unref(pkt);
 +        if (buf) {
 +            av_buffer_unref(buf);


### PR DESCRIPTION
## Summary

Merge the previously completed and reviewed issue branches into `main`, preserving their original commits:

- reject oversized or malformed embedded artwork safely (#86)
- align queue Center press and hold behavior with other track lists (#79)
- add the live sleep-timer countdown and clear expired timer state (#80, #81)

The already-merged browse-track artist navigation fix (#76) remains unchanged.

## Verification

- PASS: focused artwork, queue/navigation, and sleep-timer regression suites
- PASS: full `testDebugUnitTest` suite (891 tests)
- PASS: rebuilt Android API 19 ARMv7 native runtime and `verifyNativeAudioStamp`
- Integration diff contains only the existing completed issue changes

Fixes #79
Fixes #80
Fixes #81
Fixes #86