### PR TITLE
Remove transition mode from Now Playing footer

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
@@ -1652,7 +1652,7 @@ class Y2PlayerView(
         paint.style = Paint.Style.FILL
         paint.color = palette.divider
         canvas.drawRect(x + 8f * density, top + 7f * density, x + 9f * density, top + 23f * density, paint)
-        x = drawFooterStatus(
+        drawFooterStatus(
             canvas,
             x + 18f * density,
             top,
@@ -1660,24 +1660,6 @@ class Y2PlayerView(
             "Repeat",
             Y2UiLogic.repeatStatusLabel(state.playback.repeatMode),
             state.playback.repeatMode != RepeatMode.OFF
-        )
-        paint.style = Paint.Style.FILL
-        paint.color = palette.divider
-        canvas.drawRect(x + 8f * density, top + 7f * density, x + 9f * density, top + 23f * density, paint)
-        val transition = Y2UiLogic.transitionPresentation(
-            state.preferences.gaplessEnabled,
-            state.preferences.crossfadeMs,
-            state.preferences.crossfadeMode,
-            state.playback.shuffleEnabled
-        )
-        drawFooterStatus(
-            canvas,
-            x + 18f * density,
-            top,
-            Y2Icon.CROSSFADE,
-            if (width / density < 420f) "Mode" else "Transition",
-            transition.label,
-            transition.active
         )
     }
 
@@ -2256,13 +2238,6 @@ class Y2PlayerView(
             if (value.currentScreen == Screen.NowPlaying) {
                 append(", shuffle ${Y2UiLogic.shuffleStatusLabel(value.playback.shuffleEnabled)}")
                 append(", repeat ${Y2UiLogic.repeatStatusLabel(value.playback.repeatMode)}")
-                val transition = Y2UiLogic.transitionPresentation(
-                    value.preferences.gaplessEnabled,
-                    value.preferences.crossfadeMs,
-                    value.preferences.crossfadeMode,
-                    value.playback.shuffleEnabled
-                )
-                append(", transition ${transition.label}")
             }
             append(", output ${cachedRoute.label}")
         }

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2UiLogic.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2UiLogic.kt
@@ -4,8 +4,6 @@ import com.schulzcode.y2player.core.model.AudioOutputRoute
 import com.schulzcode.y2player.core.model.AudioQualityMode
 import com.schulzcode.y2player.core.model.PlaybackStatus
 import com.schulzcode.y2player.core.model.RepeatMode
-import com.schulzcode.y2player.playback.CrossfadeMode
-import java.util.Locale
 
 enum class RowVisualState { FOCUSED, FOCUSED_ACTIVE, ACTIVE, NORMAL, UNAVAILABLE }
 enum class ArtworkVisual { EMBEDDED, FALLBACK }
@@ -15,7 +13,6 @@ enum class RouteIcon { HEADPHONES, BLUETOOTH, SPEAKER, DISCONNECTED, UNKNOWN }
 enum class PlayerLayout { WIDE, TALL }
 
 data class RoutePresentation(val label: String, val icon: RouteIcon, val warning: Boolean = false)
-data class TransitionPresentation(val label: String, val active: Boolean)
 
 object Y2UiLogic {
     private val wiredRoute = RoutePresentation("Wired", RouteIcon.HEADPHONES)
@@ -138,29 +135,6 @@ object Y2UiLogic {
         RepeatMode.OFF -> "Off"
         RepeatMode.ALL -> "All"
         RepeatMode.ONE -> "One"
-    }
-
-    fun transitionPresentation(
-        gaplessEnabled: Boolean,
-        crossfadeMs: Int,
-        crossfadeMode: CrossfadeMode,
-        shuffleEnabled: Boolean
-    ): TransitionPresentation {
-        val effectiveCrossfadeMs = crossfadeMode.effectiveMs(crossfadeMs, shuffleEnabled)
-        return when {
-            effectiveCrossfadeMs > 0 -> TransitionPresentation(
-                "Fade ${secondsLabel(effectiveCrossfadeMs)}",
-                active = true
-            )
-            gaplessEnabled -> TransitionPresentation("Gapless", active = true)
-            else -> TransitionPresentation("Standard", active = false)
-        }
-    }
-
-    private fun secondsLabel(milliseconds: Long): String = if (milliseconds % 1000L == 0L) {
-        "${milliseconds / 1000L}s"
-    } else {
-        String.format(Locale.US, "%.1fs", milliseconds / 1000.0)
     }
 
     fun artworkVisual(hasArtwork: Boolean): ArtworkVisual = if (hasArtwork) ArtworkVisual.EMBEDDED else ArtworkVisual.FALLBACK

--- a/app/src/test/kotlin/com/schulzcode/y2player/ui/Y2UiLogicTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/ui/Y2UiLogicTest.kt
@@ -8,8 +8,9 @@ import com.schulzcode.y2player.core.model.PlaybackStatus
 import com.schulzcode.y2player.core.model.RepeatMode
 import com.schulzcode.y2player.core.state.AppState
 import com.schulzcode.y2player.core.state.ScreenContent
-import com.schulzcode.y2player.playback.CrossfadeMode
+import java.io.File
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -23,27 +24,18 @@ class Y2UiLogicTest {
         assertEquals("One", Y2UiLogic.repeatStatusLabel(RepeatMode.ONE))
     }
 
-    @Test fun transitionFooterReportsTheEffectiveMode() {
-        assertEquals(
-            TransitionPresentation("Gapless", active = true),
-            Y2UiLogic.transitionPresentation(true, 0, CrossfadeMode.ALWAYS, shuffleEnabled = false)
-        )
-        assertEquals(
-            TransitionPresentation("Fade 3s", active = true),
-            Y2UiLogic.transitionPresentation(true, 3_000, CrossfadeMode.ALWAYS, shuffleEnabled = false)
-        )
-        assertEquals(
-            TransitionPresentation("Gapless", active = true),
-            Y2UiLogic.transitionPresentation(true, 3_000, CrossfadeMode.WHILE_SHUFFLING, shuffleEnabled = false)
-        )
-        assertEquals(
-            TransitionPresentation("Fade 3s", active = true),
-            Y2UiLogic.transitionPresentation(true, 3_000, CrossfadeMode.WHILE_SHUFFLING, shuffleEnabled = true)
-        )
-        assertEquals(
-            TransitionPresentation("Standard", active = false),
-            Y2UiLogic.transitionPresentation(false, 0, CrossfadeMode.ALWAYS, shuffleEnabled = false)
-        )
+    @Test fun nowPlayingFooterOmitsTransitionAndKeepsUsefulStatuses() {
+        val source = y2PlayerViewSource()
+        val footer = source.substringAfter("private fun drawNowPlayingFooterStatuses")
+            .substringBefore("private fun drawFooterStatus")
+        val compactFooter = source.substringAfter("private fun drawCompactFooter")
+            .substringBefore("private fun drawNowPlayingFooterStatuses")
+
+        assertTrue(footer.contains("Y2Icon.SHUFFLE"))
+        assertTrue(footer.contains("Y2Icon.REPEAT"))
+        assertFalse(footer.contains("Y2Icon.CROSSFADE"))
+        assertFalse(footer.contains("transitionPresentation"))
+        assertTrue("queue position remains right-aligned", compactFooter.contains("cachedFooterPosition"))
     }
 
     @Test fun themeUsesOneReadableAccentOnDarkSurfaces() {
@@ -222,6 +214,19 @@ class Y2UiLogicTest {
         val brighter = maxOf(luminance(first), luminance(second))
         val darker = minOf(luminance(first), luminance(second))
         return (brighter + 0.05) / (darker + 0.05)
+    }
+
+    private fun y2PlayerViewSource(): String {
+        var directory: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        while (directory != null) {
+            val source = File(
+                directory,
+                "app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt"
+            )
+            if (source.isFile) return source.readText()
+            directory = directory.parentFile
+        }
+        throw AssertionError("repository root not found")
     }
 
     private fun luminance(color: Int): Double {


### PR DESCRIPTION
## Summary

Remove the permanent Transition/Mode item and its divider from the Now Playing footer. Shuffle and Repeat remain on the left, while queue position remains right-aligned, so the footer stays balanced without an empty placeholder.

This removes only footer/status presentation. Gapless, Crossfade, Crossfade Mode, their settings UI, and playback behavior are unchanged.

## Tests

- PASS: `Y2UiLogicTest`, `AppReducerTest`, and `UiCorrectnessTest`
- PASS: full `testDebugUnitTest` suite (891 tests)

Fixes #83