### PR TITLE
Allow Back to dismiss transient alerts

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
@@ -18,7 +18,11 @@ object AppReducer {
         AppAction.Confirm -> confirm(state)
         AppAction.ConfirmLong -> confirmLong(state)
         AppAction.ShowNowPlaying -> showNowPlaying(state)
-        AppAction.Back -> back(state)
+        AppAction.Back -> if (state.transientMessage != null) {
+            Reduction(state.copy(transientMessage = null))
+        } else {
+            back(state)
+        }
         AppAction.NavigateHome -> Reduction(
             if (state.screenStack.size == 1 && state.currentScreen == Screen.MainMenu) state
             else state.copy(screenStack = listOf(ScreenEntry(Screen.MainMenu)))

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/TransientMessageBackTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/TransientMessageBackTest.kt
@@ -1,0 +1,70 @@
+package com.schulzcode.y2player.core.state
+
+import com.schulzcode.y2player.core.model.LibraryState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TransientMessageBackTest {
+    @Test fun backDismissesTransientMessageBeforeNavigating() {
+        val state = AppState(
+            screenStack = listOf(ScreenEntry(Screen.MainMenu), ScreenEntry(Screen.Music)),
+            transientMessage = "Temporary alert"
+        )
+
+        val dismissed = AppReducer.reduce(state, AppAction.Back)
+
+        assertNull(dismissed.state.transientMessage)
+        assertEquals(state.screenStack, dismissed.state.screenStack)
+        assertTrue(dismissed.effects.isEmpty())
+
+        val navigated = AppReducer.reduce(dismissed.state, AppAction.Back)
+
+        assertEquals(Screen.MainMenu, navigated.state.currentScreen)
+        assertEquals(1, navigated.state.screenStack.size)
+    }
+
+    @Test fun backWithoutTransientMessageKeepsExistingNavigationBehavior() {
+        val state = AppState(
+            screenStack = listOf(ScreenEntry(Screen.MainMenu), ScreenEntry(Screen.Music))
+        )
+
+        val result = AppReducer.reduce(state, AppAction.Back)
+
+        assertEquals(Screen.MainMenu, result.state.currentScreen)
+        assertEquals(1, result.state.screenStack.size)
+    }
+
+    @Test fun dismissingOneMessageDoesNotBlockLaterMessages() {
+        val dismissed = AppReducer.reduce(
+            AppState(transientMessage = "First alert"),
+            AppAction.Back
+        ).state
+
+        val next = AppReducer.reduce(dismissed, AppAction.ShowMessage("Next alert"))
+
+        assertEquals("Next alert", next.state.transientMessage)
+    }
+
+    @Test fun persistentStatusErrorsDoNotInterceptBack() {
+        val state = AppState(
+            screenStack = listOf(ScreenEntry(Screen.MainMenu), ScreenEntry(Screen.Music)),
+            library = LibraryState(errorMessage = "Library scan failed")
+        )
+
+        val result = AppReducer.reduce(state, AppAction.Back)
+
+        assertEquals(Screen.MainMenu, result.state.currentScreen)
+        assertEquals("Library scan failed", result.state.library.errorMessage)
+    }
+
+    @Test fun rootBackWithoutTransientMessageRemainsANoOp() {
+        val state = AppState()
+
+        val result = AppReducer.reduce(state, AppAction.Back)
+
+        assertEquals(state, result.state)
+        assertTrue(result.effects.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

Previously, `AppAction.Back` always entered navigation immediately, even when the authoritative `transientMessage` banner state was active.

Back now clears a visible transient message first without changing the screen stack or emitting navigation effects. A subsequent Back press uses the existing navigation behavior. Persistent library/playback/Bluetooth/diagnostic status fields are not intercepted, and later transient messages can still appear normally.

## Tests

- PASS: focused `TransientMessageBackTest`, `AppReducerTest`, `NavigationCorrectnessTest`, and `ScreenCatalogueTest`
- PASS: full `testDebugUnitTest` suite (896 tests)

Fixes #82