### PR TITLE
Add USB connection haptic feedback

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/Y2Application.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/Y2Application.kt
@@ -13,6 +13,7 @@ import android.os.SystemClock
 import com.schulzcode.y2player.diagnostics.Ev
 import com.schulzcode.y2player.diagnostics.Sub
 import com.schulzcode.y2player.core.state.ScreenContent
+import com.schulzcode.y2player.input.HapticPolicy
 import com.schulzcode.y2player.library.ScanReason
 import com.schulzcode.y2player.playback.MediaButtonReceiver
 import com.schulzcode.y2player.playback.NativeAudio
@@ -62,8 +63,17 @@ class Y2Application : Application() {
         container.libraryRepository.scan(ScanReason.fromContentHint(reason))
     }
 
-    private val usbCoordinator = UsbStateMonitor.Listener { usb ->
+    private val usbCoordinator = UsbStateMonitor.Listener { usb, becameConnected ->
         container.diagnosticsRepository.setUsbState(usb)
+        if (becameConnected) {
+            val haptics = container.hapticController
+            if (HapticPolicy.shouldPulse(
+                    container.preferences.snapshot().hapticLevel,
+                    haptics.available,
+                    accepted = true
+                )
+            ) haptics.acceptedAction()
+        }
     }
 
     private val bluetoothOwnershipReceiver = object : BroadcastReceiver() {

--- a/app/src/main/kotlin/com/schulzcode/y2player/storage/UsbStateMonitor.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/storage/UsbStateMonitor.kt
@@ -17,7 +17,7 @@ class UsbStateMonitor(
     context: Context,
     private val eventLog: EventLog? = null
 ) {
-    fun interface Listener { fun onUsbStateChanged(state: UsbState) }
+    fun interface Listener { fun onUsbStateChanged(state: UsbState, becameConnected: Boolean) }
 
     private val appContext = context.applicationContext
     private val listeners = CopyOnWriteArraySet<Listener>()
@@ -26,6 +26,7 @@ class UsbStateMonitor(
         Thread(runnable, "y2-usb").apply { isDaemon = true; priority = Thread.MIN_PRIORITY }
     }
     private var registered = false
+    private var snapshotSeen = false
 
     @Volatile private var latest = UsbState()
     @Volatile private var broadcastConnected = false
@@ -55,7 +56,7 @@ class UsbStateMonitor(
 
     fun addListener(listener: Listener, emitImmediately: Boolean = true) {
         listeners += listener
-        if (emitImmediately) listener.onUsbStateChanged(latest)
+        if (emitImmediately) listener.onUsbStateChanged(latest, becameConnected = false)
     }
 
     fun removeListener(listener: Listener) { listeners -= listener }
@@ -92,7 +93,14 @@ class UsbStateMonitor(
                 rawState = readNode(UsbSysfs.STATE_PATH)
             )
             val previous = latest
+            val initialSnapshot = !snapshotSeen
+            snapshotSeen = true
             if (state == previous) return@execute
+            val becameConnected = UsbConnectionTransitionPolicy.becameConnected(
+                previous.connected,
+                state.connected,
+                initialSnapshot
+            )
             latest = state
             eventLog?.info(
                 Sub.USB, Ev.USB_STATE,
@@ -108,7 +116,7 @@ class UsbStateMonitor(
             if (state.functions != previous.functions) {
                 eventLog?.info(Sub.USB, Ev.USB_FUNCTIONS, "functions" to state.functions)
             }
-            handler.post { listeners.forEach { it.onUsbStateChanged(state) } }
+            handler.post { listeners.forEach { it.onUsbStateChanged(state, becameConnected) } }
         }
     }
 
@@ -126,6 +134,11 @@ class UsbStateMonitor(
         const val EXTRA_CONNECTED = "connected"
         const val EXTRA_CONFIGURED = "configured"
     }
+}
+
+internal object UsbConnectionTransitionPolicy {
+    fun becameConnected(previousConnected: Boolean, currentConnected: Boolean, initialSnapshot: Boolean): Boolean =
+        !initialSnapshot && !previousConnected && currentConnected
 }
 
 internal object UsbRefreshPolicy {

--- a/app/src/test/kotlin/com/schulzcode/y2player/input/HapticPolicyTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/input/HapticPolicyTest.kt
@@ -1,5 +1,6 @@
 package com.schulzcode.y2player.input
 
+import com.schulzcode.y2player.storage.UsbConnectionTransitionPolicy
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -96,6 +97,30 @@ class HapticPolicyTest {
     @Test fun noPulseWhenTurnedOff() {
         assertFalse(
             HapticPolicy.shouldPulse(HapticLevel.OFF, available = true, accepted = true)
+        )
+    }
+
+    @Test fun usbConnectionDoesNotPulseWhenHapticsAreTurnedOff() {
+        val becameConnected = UsbConnectionTransitionPolicy.becameConnected(
+            previousConnected = false,
+            currentConnected = true,
+            initialSnapshot = false
+        )
+
+        assertFalse(
+            HapticPolicy.shouldPulse(HapticLevel.OFF, available = true, accepted = becameConnected)
+        )
+    }
+
+    @Test fun usbConnectionPulsesWhenHapticsAreEnabled() {
+        val becameConnected = UsbConnectionTransitionPolicy.becameConnected(
+            previousConnected = false,
+            currentConnected = true,
+            initialSnapshot = false
+        )
+
+        assertTrue(
+            HapticPolicy.shouldPulse(HapticLevel.LIGHT, available = true, accepted = becameConnected)
         )
     }
 

--- a/app/src/test/kotlin/com/schulzcode/y2player/storage/UsbRefreshPolicyTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/storage/UsbRefreshPolicyTest.kt
@@ -6,6 +6,33 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class UsbRefreshPolicyTest {
+    @Test fun oneHapticCandidateIsProducedPerDisconnectedToConnectedTransition() {
+        var previousConnected = false
+        var initialSnapshot = true
+        val candidates = listOf(false, true, true, false, true).map { currentConnected ->
+            UsbConnectionTransitionPolicy.becameConnected(
+                previousConnected,
+                currentConnected,
+                initialSnapshot
+            ).also {
+                previousConnected = currentConnected
+                initialSnapshot = false
+            }
+        }
+
+        assertEquals(listOf(false, true, false, false, true), candidates)
+    }
+
+    @Test fun anInitiallyConnectedDeviceDoesNotLookLikeANewConnection() {
+        assertFalse(
+            UsbConnectionTransitionPolicy.becameConnected(
+                previousConnected = false,
+                currentConnected = true,
+                initialSnapshot = true
+            )
+        )
+    }
+
     @Test fun unchangedChargingDoesNotRefresh() {
         assertFalse(UsbRefreshPolicy.onChargingSignal(currentCharging = true, reportedCharging = true).refresh)
         assertFalse(UsbRefreshPolicy.onChargingSignal(currentCharging = false, reportedCharging = false).refresh)


### PR DESCRIPTION
## Summary

Use the existing coalesced `UsbStateMonitor` snapshot as the authoritative USB signal and mark only an observed, non-initial disconnected-to-connected transition as a connection event.

`Y2Application` routes that single event through the existing `HapticPolicy` and shared `HapticController`. Initial snapshots, duplicate USB/power broadcasts, connected-state refreshes, and disconnects do not vibrate. The current haptic level and hardware availability continue to determine whether feedback is produced.

## Tests

- PASS: focused `UsbRefreshPolicyTest`, `UsbSysfsTest`, and `HapticPolicyTest`
- PASS: full `testDebugUnitTest` suite (900 tests)

Fixes #84