### PR TITLE
Add iPod-style alphabet wheel scrolling

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AlphabetNavigation.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AlphabetNavigation.kt
@@ -1,0 +1,133 @@
+package com.schulzcode.y2player.core.state
+
+import com.schulzcode.y2player.core.model.AlbumSortOrder
+import com.schulzcode.y2player.core.model.NaturalTextOrder
+import com.schulzcode.y2player.core.model.TrackSortOrder
+import java.lang.ref.WeakReference
+import java.util.Locale
+
+/** Alphabet navigation policy and its per-row-list first-letter index. */
+object AlphabetNavigation {
+    private var cachedRows: WeakReference<List<ScreenRow>>? = null
+    private var cachedScreen: Screen? = null
+    private var cachedIndex: AlphabetIndex? = null
+    private var indexBuildCount = 0
+
+    @Synchronized
+    fun allowsScrubbing(state: AppState): Boolean = index(state, ScreenContent.rows(state)) != null
+
+    @Synchronized
+    fun move(state: AppState, direction: Int): AppState? {
+        val rows = ScreenContent.rows(state)
+        val index = index(state, rows) ?: return null
+        val step = if (direction < 0) -1 else 1
+        val currentBucket = state.alphabetScrub?.bucket
+            ?: index.bucketForSelection(state.selectedIndex, step)
+        val targetBucket = (currentBucket + step).coerceIn(FIRST_BUCKET, LAST_BUCKET)
+        val targetRow = if (targetBucket == currentBucket) null else index.firstRow(targetBucket)
+        val stack = if (targetRow == null || targetRow == state.selectedIndex) {
+            state.screenStack
+        } else {
+            state.screenStack.dropLast(1) + state.currentEntry.copy(selectedIndex = targetRow)
+        }
+        return state.copy(
+            screenStack = stack,
+            alphabetScrub = AlphabetScrubState(targetBucket)
+        )
+    }
+
+    fun label(bucket: Int): String = if (bucket <= FIRST_BUCKET) "#" else {
+        ('A'.code + bucket - 1).toChar().toString()
+    }
+
+    @Synchronized
+    fun clearCachedIndex() {
+        cachedRows = null
+        cachedScreen = null
+        cachedIndex = null
+    }
+
+    @Synchronized
+    internal fun indexBuildCountForTests(): Int = indexBuildCount
+
+    @Synchronized
+    internal fun resetForTests() {
+        clearCachedIndex()
+        indexBuildCount = 0
+    }
+
+    private fun index(state: AppState, rows: List<ScreenRow>): AlphabetIndex? {
+        if (!supportsEffectiveOrder(state) || rows.size < MIN_ROWS) return null
+        if (cachedRows?.get() === rows && cachedScreen == state.currentScreen) return cachedIndex
+
+        val firstRows = IntArray(BUCKET_COUNT) { -1 }
+        var eligibleRows = 0
+        var previousPlaylistTitle: String? = null
+        var playlistOrderValid = true
+        rows.forEachIndexed { rowIndex, row ->
+            val title = alphabetTitle(state.currentScreen, row) ?: return@forEachIndexed
+            if (state.currentScreen == Screen.Playlists) {
+                val previous = previousPlaylistTitle
+                if (previous != null && NaturalTextOrder.compare(previous, title) > 0) {
+                    playlistOrderValid = false
+                }
+                previousPlaylistTitle = title
+            }
+            eligibleRows += 1
+            val bucket = bucket(title)
+            if (firstRows[bucket] < 0) firstRows[bucket] = rowIndex
+        }
+        indexBuildCount += 1
+        val built = if (eligibleRows >= MIN_ROWS && playlistOrderValid) AlphabetIndex(firstRows) else null
+        cachedRows = WeakReference(rows)
+        cachedScreen = state.currentScreen
+        cachedIndex = built
+        return built
+    }
+
+    private fun supportsEffectiveOrder(state: AppState): Boolean = when (val screen = state.currentScreen) {
+        Screen.Songs, Screen.Favorites -> state.preferences.sortOrder == TrackSortOrder.TITLE
+        Screen.Albums, is Screen.ArtistAlbums, is Screen.FacetAlbums,
+        is Screen.FacetArtistAlbums -> state.preferences.albumSortOrder == AlbumSortOrder.TITLE
+        Screen.Artists, is Screen.FacetArtists, Screen.Playlists -> true
+        is Screen.FacetTracks -> screen.artist == null && screen.album == null &&
+            state.preferences.sortOrder == TrackSortOrder.TITLE
+        else -> false
+    }
+
+    private fun alphabetTitle(screen: Screen, row: ScreenRow): String? = when (screen) {
+        Screen.Songs, Screen.Favorites, is Screen.FacetTracks ->
+            (row as? ScreenRow.TrackRow)?.title
+        Screen.Albums, is Screen.ArtistAlbums, is Screen.FacetAlbums,
+        is Screen.FacetArtistAlbums, Screen.Artists, is Screen.FacetArtists ->
+            (row as? ScreenRow.Group)?.title
+        Screen.Playlists -> (row as? ScreenRow.Action)?.takeIf {
+            it.key.startsWith("playlist:")
+        }?.title
+        else -> null
+    }
+
+    private fun bucket(title: String): Int {
+        val first = title.trim().uppercase(Locale.US).firstOrNull() ?: return FIRST_BUCKET
+        return if (first in 'A'..'Z') first.code - 'A'.code + 1 else FIRST_BUCKET
+    }
+
+    private class AlphabetIndex(private val firstRows: IntArray) {
+        fun firstRow(bucket: Int): Int? = firstRows[bucket].takeIf { it >= 0 }
+
+        fun bucketForSelection(selectedIndex: Int, direction: Int): Int {
+            var directBucket = -1
+            for (bucket in FIRST_BUCKET..LAST_BUCKET) {
+                if (firstRows[bucket] == selectedIndex) return bucket
+                if (firstRows[bucket] in 0..selectedIndex) directBucket = bucket
+            }
+            if (directBucket >= 0) return directBucket
+            return if (direction > 0) FIRST_BUCKET - 1 else LAST_BUCKET + 1
+        }
+    }
+
+    private const val MIN_ROWS = 12
+    private const val FIRST_BUCKET = 0
+    private const val LAST_BUCKET = 26
+    private const val BUCKET_COUNT = LAST_BUCKET + 1
+}

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppAction.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppAction.kt
@@ -9,6 +9,8 @@ import com.schulzcode.y2player.diagnostics.DiagnosticsState
 
 sealed interface AppAction {
     data class WheelMoved(val delta: Int) : AppAction
+    data class AlphabetMoved(val direction: Int) : AppAction
+    data object EndAlphabetScrub : AppAction
     data object Confirm : AppAction
     data object ConfirmLong : AppAction
     data object ShowNowPlaying : AppAction
@@ -134,6 +136,8 @@ data class Reduction(val state: AppState, val effects: List<AppEffect> = emptyLi
 // R8 renames these classes, so simpleName logs as `b0` in release builds.
 val AppAction.code: String get() = when (this) {
     is AppAction.WheelMoved -> if (delta >= 0) "wheel_clockwise" else "wheel_counter_clockwise"
+    is AppAction.AlphabetMoved -> if (direction >= 0) "alphabet_clockwise" else "alphabet_counter_clockwise"
+    AppAction.EndAlphabetScrub -> "alphabet_end"
     AppAction.Confirm -> "confirm"
     AppAction.ConfirmLong -> "confirm_long"
     AppAction.ShowNowPlaying -> "show_now_playing"

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
@@ -14,18 +14,20 @@ import com.schulzcode.y2player.playback.AudioBalance
 
 object AppReducer {
     fun reduce(state: AppState, action: AppAction): Reduction = when (action) {
-        is AppAction.WheelMoved -> moveSelection(state, action.delta)
-        AppAction.Confirm -> confirm(state)
-        AppAction.ConfirmLong -> confirmLong(state)
-        AppAction.ShowNowPlaying -> showNowPlaying(state)
+        is AppAction.WheelMoved -> moveSelection(clearAlphabetScrub(state), action.delta)
+        is AppAction.AlphabetMoved -> moveAlphabet(state, action.direction)
+        AppAction.EndAlphabetScrub -> Reduction(clearAlphabetScrub(state))
+        AppAction.Confirm -> confirm(clearAlphabetScrub(state))
+        AppAction.ConfirmLong -> confirmLong(clearAlphabetScrub(state))
+        AppAction.ShowNowPlaying -> showNowPlaying(clearAlphabetScrub(state))
         AppAction.Back -> if (state.transientMessage != null) {
-            Reduction(state.copy(transientMessage = null))
+            Reduction(clearAlphabetScrub(state).copy(transientMessage = null))
         } else {
-            back(state)
+            back(clearAlphabetScrub(state))
         }
         AppAction.NavigateHome -> Reduction(
-            if (state.screenStack.size == 1 && state.currentScreen == Screen.MainMenu) state
-            else state.copy(screenStack = listOf(ScreenEntry(Screen.MainMenu)))
+            if (state.screenStack.size == 1 && state.currentScreen == Screen.MainMenu) clearAlphabetScrub(state)
+            else clearAlphabetScrub(state).copy(screenStack = listOf(ScreenEntry(Screen.MainMenu)))
         )
         AppAction.Left -> Reduction(state, listOf(PreviousTrack))
         AppAction.Right -> Reduction(state, listOf(NextTrack))
@@ -37,12 +39,12 @@ object AppReducer {
         AppAction.SeekForward -> Reduction(state, listOf(SeekBy(state.preferences.seekStepMs.toLong())))
         AppAction.SeekBackwardLong -> Reduction(state, listOf(SeekBy(-state.preferences.longSeekStepMs.toLong())))
         AppAction.SeekForwardLong -> Reduction(state, listOf(SeekBy(state.preferences.longSeekStepMs.toLong())))
-        is AppAction.LibraryChanged -> Reduction(preserveSelection(state, state.copy(library = action.library)))
+        is AppAction.LibraryChanged -> Reduction(preserveSelection(state, state.copy(library = action.library, alphabetScrub = null)))
         is AppAction.PlaybackChanged -> Reduction(playbackChanged(state, action.playback))
         is AppAction.DeviceChanged -> Reduction(preserveSelection(state, state.copy(device = action.device)))
         is AppAction.BluetoothChanged -> Reduction(preserveSelection(state, state.copy(bluetooth = action.bluetooth)))
         is AppAction.DisplayChanged -> Reduction(state.copy(display = action.display))
-        is AppAction.PreferencesChanged -> Reduction(preserveSelection(state, state.copy(preferences = action.preferences)))
+        is AppAction.PreferencesChanged -> Reduction(preserveSelection(state, state.copy(preferences = action.preferences, alphabetScrub = null)))
         is AppAction.DiagnosticsChanged -> Reduction(preserveSelection(state, state.copy(diagnostics = action.diagnostics)))
         is AppAction.BackupChanged -> Reduction(preserveSelection(state, state.copy(backup = action.backup)))
         is AppAction.BackupImportReady -> Reduction(
@@ -54,8 +56,17 @@ object AppReducer {
         )
         is AppAction.SafeModeChanged -> Reduction(state.copy(safeMode = action.enabled))
         is AppAction.ShowMessage -> Reduction(state.copy(transientMessage = action.message))
-        is AppAction.SelectIndex -> Reduction(normalizeSelection(setSelected(state, action.index.coerceAtLeast(0))))
+        is AppAction.SelectIndex -> Reduction(normalizeSelection(setSelected(clearAlphabetScrub(state), action.index.coerceAtLeast(0))))
     }
+
+    private fun moveAlphabet(state: AppState, direction: Int): Reduction {
+        if (direction == 0) return Reduction(state)
+        return AlphabetNavigation.move(state, direction)?.let(::Reduction)
+            ?: Reduction(clearAlphabetScrub(state))
+    }
+
+    private fun clearAlphabetScrub(state: AppState): AppState =
+        if (state.alphabetScrub == null) state else state.copy(alphabetScrub = null)
 
     private fun playbackChanged(state: AppState, playback: com.schulzcode.y2player.core.model.PlaybackSnapshot): AppState {
         val progressOnly = isProgressOnlyUpdate(state.playback, playback)

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppState.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppState.kt
@@ -124,9 +124,14 @@ data class AppState(
     val diagnostics: DiagnosticsState = DiagnosticsState(),
     val backup: BackupUiState = BackupUiState(),
     val safeMode: Boolean = false,
-    val transientMessage: String? = null
+    val transientMessage: String? = null,
+    val alphabetScrub: AlphabetScrubState? = null
 ) {
     val currentEntry: ScreenEntry get() = screenStack.last()
     val currentScreen: Screen get() = currentEntry.screen
     val selectedIndex: Int get() = currentEntry.selectedIndex
+}
+
+data class AlphabetScrubState(val bucket: Int) {
+    val label: String get() = AlphabetNavigation.label(bucket)
 }

--- a/app/src/main/kotlin/com/schulzcode/y2player/input/WheelAcceleration.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/input/WheelAcceleration.kt
@@ -4,16 +4,32 @@ internal class WheelAcceleration {
     private var lastEventTimeMs = Long.MIN_VALUE
     private var lastDirection = 0
     private var fastEventCount = 0
+    private var alphabetScrubbing = false
 
-    fun delta(direction: Int, eventTimeMs: Long, enabled: Boolean): Int {
+    fun movement(
+        direction: Int,
+        eventTimeMs: Long,
+        enabled: Boolean,
+        alphabetEnabled: Boolean
+    ): WheelMovement {
         val normalizedDirection = if (direction < 0) -1 else 1
         if (!enabled) {
             reset()
-            return normalizedDirection
+            return WheelMovement.Rows(normalizedDirection)
         }
 
         val interval = if (lastEventTimeMs == Long.MIN_VALUE) Long.MAX_VALUE
         else (eventTimeMs - lastEventTimeMs).coerceAtLeast(0L)
+
+        if (alphabetScrubbing) {
+            if (alphabetEnabled && interval <= ALPHABET_EXIT_INTERVAL_MS) {
+                lastDirection = normalizedDirection
+                lastEventTimeMs = eventTimeMs
+                return WheelMovement.Alphabet(normalizedDirection)
+            }
+            alphabetScrubbing = false
+        }
+
         if (normalizedDirection != lastDirection || interval > MEDIUM_INTERVAL_MS) {
             fastEventCount = 0
         } else {
@@ -22,18 +38,30 @@ internal class WheelAcceleration {
         lastDirection = normalizedDirection
         lastEventTimeMs = eventTimeMs
 
+        if (alphabetEnabled && interval <= ALPHABET_INTERVAL_MS &&
+            fastEventCount >= FAST_EVENTS_FOR_ALPHABET
+        ) {
+            alphabetScrubbing = true
+            return WheelMovement.Alphabet(normalizedDirection)
+        }
+
         val step = when {
             interval <= FAST_INTERVAL_MS && fastEventCount >= FAST_EVENTS_FOR_LARGE_STEP -> LARGE_STEP
             interval <= MEDIUM_INTERVAL_MS && fastEventCount >= FAST_EVENTS_FOR_SMALL_STEP -> SMALL_STEP
             else -> 1
         }
-        return normalizedDirection * step
+        return WheelMovement.Rows(normalizedDirection * step)
+    }
+
+    fun delta(direction: Int, eventTimeMs: Long, enabled: Boolean): Int {
+        return (movement(direction, eventTimeMs, enabled, alphabetEnabled = false) as WheelMovement.Rows).delta
     }
 
     fun reset() {
         lastEventTimeMs = Long.MIN_VALUE
         lastDirection = 0
         fastEventCount = 0
+        alphabetScrubbing = false
     }
 
     companion object {
@@ -41,9 +69,19 @@ internal class WheelAcceleration {
         // decaying accumulator that could jump after the user stops.
         const val MEDIUM_INTERVAL_MS = 180L
         const val FAST_INTERVAL_MS = 90L
+        // Require about 400 ms of very fast movement before entering. The wider
+        // exit interval adds enough hysteresis that one uneven detent does not flicker modes.
+        const val ALPHABET_INTERVAL_MS = 65L
+        const val ALPHABET_EXIT_INTERVAL_MS = 130L
         const val SMALL_STEP = 3
         const val LARGE_STEP = 5
         private const val FAST_EVENTS_FOR_SMALL_STEP = 2
         private const val FAST_EVENTS_FOR_LARGE_STEP = 4
+        private const val FAST_EVENTS_FOR_ALPHABET = 8
     }
+}
+
+internal sealed interface WheelMovement {
+    data class Rows(val delta: Int) : WheelMovement
+    data class Alphabet(val direction: Int) : WheelMovement
 }

--- a/app/src/main/kotlin/com/schulzcode/y2player/input/Y2InputController.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/input/Y2InputController.kt
@@ -5,7 +5,8 @@ import com.schulzcode.y2player.core.state.AppAction
 
 class Y2InputController(
     private val dispatch: (AppAction) -> Unit,
-    private val wheelAccelerationAllowed: () -> Boolean = { false }
+    private val wheelAccelerationAllowed: () -> Boolean = { false },
+    private val alphabetScrubAllowed: () -> Boolean = { false }
 ) {
     private val longPressedKeys = HashSet<Int>()
     private val pressedKeys = HashSet<Int>()
@@ -60,12 +61,8 @@ class Y2InputController(
         }
 
         val action = when (keyCode) {
-            KeyEvent.KEYCODE_DPAD_UP -> AppAction.WheelMoved(
-                wheelAcceleration.delta(-1, event.eventTime, wheelAccelerationAllowed())
-            )
-            KeyEvent.KEYCODE_DPAD_DOWN -> AppAction.WheelMoved(
-                wheelAcceleration.delta(1, event.eventTime, wheelAccelerationAllowed())
-            )
+            KeyEvent.KEYCODE_DPAD_UP -> wheelAction(-1, event.eventTime)
+            KeyEvent.KEYCODE_DPAD_DOWN -> wheelAction(1, event.eventTime)
             KeyEvent.KEYCODE_DPAD_LEFT -> AppAction.Left
             KeyEvent.KEYCODE_DPAD_RIGHT -> AppAction.Right
             KeyEvent.KEYCODE_BACK -> AppAction.Back
@@ -82,6 +79,17 @@ class Y2InputController(
         dispatch(action)
         return true
     }
+
+    private fun wheelAction(direction: Int, eventTimeMs: Long): AppAction =
+        when (val movement = wheelAcceleration.movement(
+            direction,
+            eventTimeMs,
+            enabled = wheelAccelerationAllowed(),
+            alphabetEnabled = alphabetScrubAllowed()
+        )) {
+            is WheelMovement.Rows -> AppAction.WheelMoved(movement.delta)
+            is WheelMovement.Alphabet -> AppAction.AlphabetMoved(movement.direction)
+        }
 
     fun resetHeldKeys() {
         longPressedKeys.clear()

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/MainActivity.kt
@@ -26,6 +26,7 @@ import com.schulzcode.y2player.core.model.PlaybackStatus
 import com.schulzcode.y2player.core.state.AppAction
 import com.schulzcode.y2player.core.state.AppEffect
 import com.schulzcode.y2player.core.state.AppStore
+import com.schulzcode.y2player.core.state.AlphabetNavigation
 import com.schulzcode.y2player.core.state.ListNavigationPolicy
 import com.schulzcode.y2player.core.state.code
 import com.schulzcode.y2player.core.state.Screen
@@ -125,11 +126,12 @@ class MainActivity : Activity() {
     }
 
     private val clearMessageRunnable = Runnable { store.dispatch(AppAction.ShowMessage(null)) }
+    private val endAlphabetScrubRunnable = Runnable { store.dispatch(AppAction.EndAlphabetScrub) }
     private val markStableRunnable = Runnable { safeModeManager.markStartupStable() }
     private val effectListener = AppStore.EffectListener(::handleEffect)
 
     private val actionLogger = AppStore.ActionListener { action, state ->
-        val wheel = action is AppAction.WheelMoved
+        val wheel = action is AppAction.WheelMoved || action is AppAction.AlphabetMoved
         if (wheel) {
             eventLog.logRateLimited(
                 "wheel_action", WHEEL_LOG_WINDOW_MS,
@@ -226,10 +228,14 @@ class MainActivity : Activity() {
         if (startupSafeMode) bluetoothController.stop()
         hapticController = container.hapticController
         hapticController.setLevel(preferences.snapshot().hapticLevel)
-        inputController = Y2InputController(::dispatchInput) {
-            val current = store.state
-            ListNavigationPolicy.allowsAcceleration(current.currentScreen, ScreenContent.rows(current).size)
-        }
+        inputController = Y2InputController(
+            dispatch = ::dispatchInput,
+            wheelAccelerationAllowed = {
+                val current = store.state
+                ListNavigationPolicy.allowsAcceleration(current.currentScreen, ScreenContent.rows(current).size)
+            },
+            alphabetScrubAllowed = { AlphabetNavigation.allowsScrubbing(store.state) }
+        )
         playerView = Y2PlayerView(this, { action -> store.dispatch(action) }, container.artworkLoader)
         playerView.isSoundEffectsEnabled = preferences.snapshot().uiSoundEffectsEnabled
         setContentView(playerView)
@@ -323,6 +329,8 @@ class MainActivity : Activity() {
         unbindPlaybackServiceIfNeeded()
         unregisterVisibleStateListeners()
         inputController.resetHeldKeys()
+        mainHandler.removeCallbacks(endAlphabetScrubRunnable)
+        store.dispatch(AppAction.EndAlphabetScrub)
         HardwareKeyGate.invalidateScreenState()
         super.onStop()
     }
@@ -344,6 +352,7 @@ class MainActivity : Activity() {
     override fun onDestroy() {
         destroyed = true
         mainHandler.removeCallbacks(clearMessageRunnable)
+        mainHandler.removeCallbacks(endAlphabetScrubRunnable)
         mainHandler.removeCallbacks(markStableRunnable)
         unbindPlaybackServiceIfNeeded()
         libraryRepository.removeListener(libraryListener)
@@ -657,10 +666,19 @@ class MainActivity : Activity() {
     }
 
     private fun dispatchInput(action: AppAction) {
-        val wheel = action is AppAction.WheelMoved
-        val adjustsNowPlayingVolume = wheel && store.state.currentScreen == Screen.NowPlaying
+        val wheel = action is AppAction.WheelMoved || action is AppAction.AlphabetMoved
+        val adjustsNowPlayingVolume = action is AppAction.WheelMoved &&
+            store.state.currentScreen == Screen.NowPlaying
         if (wheel) playerView.onNavigationInput()
         val accepted = store.dispatch(action)
+        if (action is AppAction.AlphabetMoved) {
+            mainHandler.removeCallbacks(endAlphabetScrubRunnable)
+            if (store.state.alphabetScrub != null) {
+                mainHandler.postDelayed(endAlphabetScrubRunnable, ALPHABET_SCRUB_TIMEOUT_MS)
+            }
+        } else if (action is AppAction.WheelMoved) {
+            mainHandler.removeCallbacks(endAlphabetScrubRunnable)
+        }
         if (accepted && !adjustsNowPlayingVolume) pulseAcceptedAction()
     }
 
@@ -835,6 +853,7 @@ class MainActivity : Activity() {
         private const val SAFE_MODE_KEY_WINDOW_MS = 5_000L
         private const val VOLUME_LOG_WINDOW_MS = 5_000L
         private const val WHEEL_LOG_WINDOW_MS = 1_000L
+        private const val ALPHABET_SCRUB_TIMEOUT_MS = 420L
         private const val STARTUP_STABLE_DELAY_MS = 10_000L
     }
 }

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
@@ -259,7 +259,10 @@ class Y2PlayerView(
         val sameScreenPath = oldState.screenStack.size == newState.screenStack.size &&
             oldState.screenStack.indices.all { oldState.screenStack[it].screen == newState.screenStack[it].screen }
         val selectionOnly = !themeChanged && sameScreenPath &&
-            oldState.copy(screenStack = newState.screenStack) == newState
+            oldState.copy(
+                screenStack = newState.screenStack,
+                alphabetScrub = newState.alphabetScrub
+            ) == newState
 
         state = newState
         updateSleepTimerCountdownActivity(refreshRows = false)
@@ -469,6 +472,7 @@ class Y2PlayerView(
         if (isSplitHome()) drawHomePane(canvas)
         drawFooter(canvas)
         drawStatusMessage(canvas)
+        drawAlphabetScrubOverlay(canvas)
         if (state.currentScreen.isRadialMenu()) {
             drawRadialOptionsOverlay(canvas, state, rows, radialAnimationProgress())
         } else {
@@ -1717,6 +1721,34 @@ class Y2PlayerView(
         paint.textSize = Y2UiTheme.META_SP * density
         paint.color = palette.secondaryText
         canvas.drawText(cachedMessageBody, 46f * density, top + 42f * density, paint)
+    }
+
+    private fun drawAlphabetScrubOverlay(canvas: Canvas) {
+        val label = state.alphabetScrub?.label ?: return
+        val centerX = rowAreaRight() * .5f
+        val centerY = (rowAreaTop() + rowAreaBottom()) * .5f
+        val halfSize = 49f * density
+        reusableRectF.set(
+            centerX - halfSize,
+            centerY - halfSize,
+            centerX + halfSize,
+            centerY + halfSize
+        )
+        paint.style = Paint.Style.FILL
+        paint.color = palette.surfaceRaised
+        canvas.drawRoundRect(reusableRectF, 16f * density, 16f * density, paint)
+        paint.style = Paint.Style.STROKE
+        paint.strokeWidth = 2f * density
+        paint.color = palette.accent
+        canvas.drawRoundRect(reusableRectF, 16f * density, 16f * density, paint)
+        paint.style = Paint.Style.FILL
+
+        boldPaint.textAlign = Paint.Align.CENTER
+        boldPaint.textSize = 54f * density
+        boldPaint.color = palette.primaryText
+        val baseline = centerY - (boldPaint.ascent() + boldPaint.descent()) * .5f
+        canvas.drawText(label, centerX, baseline, boldPaint)
+        boldPaint.textAlign = Paint.Align.LEFT
     }
 
     private fun updatePresentationCache() {

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/AlphabetNavigationTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/AlphabetNavigationTest.kt
@@ -1,0 +1,237 @@
+package com.schulzcode.y2player.core.state
+
+import com.schulzcode.y2player.core.model.AlbumSortOrder
+import com.schulzcode.y2player.core.model.LibraryScope
+import com.schulzcode.y2player.core.model.LibraryState
+import com.schulzcode.y2player.core.model.PlaylistSummary
+import com.schulzcode.y2player.core.model.Track
+import com.schulzcode.y2player.core.model.TrackSortOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AlphabetNavigationTest {
+    @Before fun clearCaches() {
+        ScreenContent.clearCachedRows()
+        AlphabetNavigation.resetForTests()
+    }
+
+    @Test fun scrubMovesForwardAndBackwardAndJumpsToTheFirstMatchingRow() {
+        val titles = ('A'..'Z').map { "$it first" } + listOf("M second")
+        var state = songsState(titles)
+        state = selectTitle(state, "H first")
+
+        val forward = AppReducer.reduce(state, AppAction.AlphabetMoved(1))
+        assertTrue(forward.effects.isEmpty())
+        state = forward.state
+        assertEquals("I", state.alphabetScrub?.label)
+        assertEquals("I first", selectedTitle(state))
+
+        state = AppReducer.reduce(state, AppAction.AlphabetMoved(-1)).state
+        assertEquals("H", state.alphabetScrub?.label)
+        assertEquals("H first", selectedTitle(state))
+
+        state = selectTitle(state.copy(alphabetScrub = null), "L first")
+        state = AppReducer.reduce(state, AppAction.AlphabetMoved(1)).state
+        assertEquals("M first", selectedTitle(state))
+    }
+
+    @Test fun nonAlphabeticTitlesUseTheNumberBucket() {
+        var state = songsState(listOf("123", "! Alert") + ('A'..'Z').map { "$it song" })
+        state = selectTitle(state, "A song")
+
+        state = AppReducer.reduce(state, AppAction.AlphabetMoved(-1)).state
+
+        assertEquals("#", state.alphabetScrub?.label)
+        assertEquals("! Alert", selectedTitle(state))
+    }
+
+    @Test fun missingLettersRemainSafeAndTheNextPresentLetterJumps() {
+        val titles = ('A'..'Z').filterNot { it == 'Q' }.map { "$it song" }
+        var state = selectTitle(songsState(titles), "P song")
+
+        state = AppReducer.reduce(state, AppAction.AlphabetMoved(1)).state
+        assertEquals("Q", state.alphabetScrub?.label)
+        assertEquals("P song", selectedTitle(state))
+
+        state = AppReducer.reduce(state, AppAction.AlphabetMoved(1)).state
+        assertEquals("R", state.alphabetScrub?.label)
+        assertEquals("R song", selectedTitle(state))
+    }
+
+    @Test fun endingScrubKeepsTheJumpedSelectionAndDismissesTheIndicator() {
+        var state = selectTitle(songsState(('A'..'Z').map { "$it song" }), "H song")
+        state = AppReducer.reduce(state, AppAction.AlphabetMoved(1)).state
+        val jumpedIndex = state.selectedIndex
+
+        state = AppReducer.reduce(state, AppAction.EndAlphabetScrub).state
+
+        assertNull(state.alphabetScrub)
+        assertEquals(jumpedIndex, state.selectedIndex)
+        assertEquals("I song", selectedTitle(state))
+    }
+
+    @Test fun normalWheelMovementAfterScrubClearsTheModeAndUsesRowNavigation() {
+        var state = selectTitle(songsState(('A'..'Z').map { "$it song" }), "H song")
+        state = AppReducer.reduce(state, AppAction.AlphabetMoved(1)).state
+        val jumpedIndex = state.selectedIndex
+
+        state = AppReducer.reduce(state, AppAction.WheelMoved(1)).state
+
+        assertNull(state.alphabetScrub)
+        assertEquals(jumpedIndex + 1, state.selectedIndex)
+    }
+
+    @Test fun eligibilityTracksTheEffectiveSortAndScreen() {
+        val tracks = ('A'..'Z').mapIndexed { index, letter ->
+            track(
+                id = index.toLong() + 1,
+                title = "$letter song",
+                artist = "$letter artist",
+                album = "$letter album",
+                year = 2000 + index
+            )
+        }
+        val library = LibraryState(tracks = tracks)
+
+        assertAllowed(state(Screen.Songs, library, trackSort = TrackSortOrder.TITLE))
+        assertDenied(state(Screen.Songs, library, trackSort = TrackSortOrder.ARTIST))
+        val favorites = LibraryState(tracks = tracks.map { it.copy(favorite = true) })
+        assertAllowed(state(Screen.Favorites, favorites, trackSort = TrackSortOrder.TITLE))
+        assertDenied(state(Screen.Favorites, favorites, trackSort = TrackSortOrder.RECENT))
+        assertAllowed(state(Screen.Artists, library))
+        assertAllowed(state(Screen.Albums, library, albumSort = AlbumSortOrder.TITLE))
+        assertDenied(state(Screen.Albums, library, albumSort = AlbumSortOrder.ARTIST))
+        assertDenied(state(Screen.Albums, library, albumSort = AlbumSortOrder.YEAR_ASCENDING))
+        assertAllowed(state(Screen.FacetAlbums(LibraryScope.All), library, albumSort = AlbumSortOrder.TITLE))
+        val oneArtistLibrary = LibraryState(tracks = tracks.map { it.copy(artist = "One Artist", albumArtist = "One Artist") })
+        assertAllowed(state(Screen.ArtistAlbums("One Artist"), oneArtistLibrary))
+        assertDenied(state(
+            Screen.ArtistAlbums("One Artist"),
+            oneArtistLibrary,
+            albumSort = AlbumSortOrder.YEAR_DESCENDING
+        ))
+
+        assertDenied(state(Screen.AlbumSongs("A album", "A artist"), library))
+        assertDenied(state(Screen.RecentlyPlayed, library))
+        assertDenied(state(Screen.Years, library))
+        assertDenied(state(Screen.Queue, library))
+        assertDenied(state(Screen.Settings, library))
+        assertDenied(state(Screen.NowPlayingOptions, library))
+    }
+
+    @Test fun facetTrackScrubRequiresAVisibleTitleSortedCollection() {
+        val tracks = ('A'..'Z').mapIndexed { index, letter ->
+            track(index.toLong() + 1, "$letter song", "Artist", "Album", genre = "Rock")
+        }
+        val library = LibraryState(tracks = tracks)
+        val scope = LibraryScope.Genre("rock", "Rock")
+
+        assertAllowed(state(Screen.FacetTracks(scope, "Rock"), library, trackSort = TrackSortOrder.TITLE))
+        assertDenied(state(Screen.FacetTracks(scope, "Rock"), library, trackSort = TrackSortOrder.ALBUM))
+        assertDenied(state(Screen.FacetTracks(scope, "Artist", artist = "Artist"), library))
+    }
+
+    @Test fun playlistsScrubOnlyWhenTheirActualOrderIsAlphabetic() {
+        val sorted = ('A'..'L').mapIndexed { index, letter ->
+            PlaylistSummary(index.toLong() + 1, "$letter list", 0)
+        }
+        val sortedState = AppState(
+            screenStack = listOf(ScreenEntry(Screen.Playlists)),
+            library = LibraryState(tracks = emptyList(), playlists = sorted)
+        )
+        assertAllowed(sortedState)
+
+        ScreenContent.clearCachedRows()
+        AlphabetNavigation.clearCachedIndex()
+        val unsortedState = sortedState.copy(
+            library = LibraryState(tracks = emptyList(), playlists = sorted.reversed())
+        )
+        assertDenied(unsortedState)
+    }
+
+    @Test fun largeListsBuildTheLetterLookupOnlyOnceAcrossWheelEvents() {
+        val tracks = ArrayList<Track>(10_000)
+        var id = 1L
+        for (letter in 'A'..'Z') {
+            repeat(385) { number ->
+                tracks += track(id++, "$letter ${number.toString().padStart(4, '0')}", "Artist", "Album")
+            }
+        }
+        var state = AppState(
+            screenStack = listOf(ScreenEntry(Screen.Songs)),
+            library = LibraryState(tracks = tracks)
+        )
+
+        assertTrue(AlphabetNavigation.allowsScrubbing(state))
+        repeat(50) {
+            state = AppReducer.reduce(state, AppAction.AlphabetMoved(1)).state
+        }
+
+        assertEquals(1, AlphabetNavigation.indexBuildCountForTests())
+    }
+
+    private fun assertAllowed(state: AppState) = assertTrue(
+        "Expected alphabet scrub on ${state.currentScreen}",
+        AlphabetNavigation.allowsScrubbing(state)
+    )
+
+    private fun assertDenied(state: AppState) = assertFalse(
+        "Expected no alphabet scrub on ${state.currentScreen}",
+        AlphabetNavigation.allowsScrubbing(state)
+    )
+
+    private fun songsState(titles: List<String>): AppState = AppState(
+        screenStack = listOf(ScreenEntry(Screen.Songs)),
+        library = LibraryState(tracks = titles.mapIndexed { index, title ->
+            track(index.toLong() + 1, title, "Artist", "Album")
+        })
+    )
+
+    private fun state(
+        screen: Screen,
+        library: LibraryState,
+        trackSort: TrackSortOrder = TrackSortOrder.TITLE,
+        albumSort: AlbumSortOrder = AlbumSortOrder.TITLE
+    ): AppState = AppState(
+        screenStack = listOf(ScreenEntry(screen)),
+        library = library,
+        preferences = PlayerPreferencesState(sortOrder = trackSort, albumSortOrder = albumSort)
+    )
+
+    private fun selectTitle(state: AppState, title: String): AppState {
+        val index = ScreenContent.rows(state).indexOfFirst { it.title == title }
+        assertTrue("Missing row $title", index >= 0)
+        return state.copy(screenStack = listOf(ScreenEntry(state.currentScreen, index)))
+    }
+
+    private fun selectedTitle(state: AppState): String = ScreenContent.rows(state)[state.selectedIndex].title
+
+    private fun track(
+        id: Long,
+        title: String,
+        artist: String,
+        album: String,
+        year: Int? = null,
+        genre: String? = null
+    ) = Track(
+        id = id,
+        volumeId = "internal",
+        absolutePath = "/music/$id.mp3",
+        relativePath = "music/$id.mp3",
+        title = title,
+        artist = artist,
+        album = album,
+        albumArtist = artist,
+        trackNumber = 1,
+        discNumber = 1,
+        durationMs = 60_000,
+        fileSize = 1_000,
+        modifiedAt = id,
+        year = year,
+        genre = genre
+    )
+}

--- a/app/src/test/kotlin/com/schulzcode/y2player/input/WheelAccelerationTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/input/WheelAccelerationTest.kt
@@ -56,4 +56,52 @@ class WheelAccelerationTest {
 
         assertEquals(1, acceleration.delta(1, 300, enabled = true))
     }
+
+    @Test fun veryFastSustainedMovementEntersAlphabetTier() {
+        val acceleration = WheelAcceleration()
+        var movement: WheelMovement = WheelMovement.Rows(0)
+
+        repeat(9) { index ->
+            movement = acceleration.movement(1, index * 50L, enabled = true, alphabetEnabled = true)
+        }
+
+        assertEquals(WheelMovement.Alphabet(1), movement)
+    }
+
+    @Test fun alphabetTierFollowsDirectionChangesWithoutAlsoMovingRows() {
+        val acceleration = WheelAcceleration()
+        repeat(9) { index ->
+            acceleration.movement(1, index * 50L, enabled = true, alphabetEnabled = true)
+        }
+
+        assertEquals(
+            WheelMovement.Alphabet(-1),
+            acceleration.movement(-1, 440L, enabled = true, alphabetEnabled = true)
+        )
+    }
+
+    @Test fun slowingDownLeavesAlphabetTierForExistingRowAcceleration() {
+        val acceleration = WheelAcceleration()
+        repeat(9) { index ->
+            acceleration.movement(1, index * 50L, enabled = true, alphabetEnabled = true)
+        }
+
+        assertEquals(
+            WheelMovement.Rows(3),
+            acceleration.movement(1, 540L, enabled = true, alphabetEnabled = true)
+        )
+    }
+
+    @Test fun alphabetTierIsNeverUsedWhenTheVisibleOrderIsIneligible() {
+        val acceleration = WheelAcceleration()
+        repeat(12) { index ->
+            val movement = acceleration.movement(
+                1,
+                index * 40L,
+                enabled = true,
+                alphabetEnabled = false
+            )
+            assertEquals(WheelMovement.Rows(if (index < 2) 1 else if (index < 4) 3 else 5), movement)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- preserve the existing normal and accelerated 1/3/5-row wheel scrolling tiers
- add a conservative sustained-speed alphabet scrub tier with a temporary large `#`/`A`–`Z` overlay
- enable scrub only for title-sorted song/favorite, artist, title-sorted album, and actually alphabetic playlist views
- precompute a 27-entry first-row lookup once per visible row list so large libraries are not rescanned per wheel event
- leave album track order, Recently Played, year-sorted albums, queue, settings, folders, and radial menus unchanged

## Tests

- Focused: `WheelAccelerationTest`, `AlphabetNavigationTest`, and `ListNavigationPolicyTest` — 27 passed
- Full unit suite: 913 executed, 910 passed; 3 unchanged `NativeFloatPipelineArchitectureTest` source-format assertions fail on current `main` as well (the native source and test files are untouched by this PR)

Fixes #44