### PR TITLE
Add long-press Back navigation to home

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/input/Y2InputController.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/input/Y2InputController.kt
@@ -35,6 +35,7 @@ class Y2InputController(
                     KeyEvent.KEYCODE_DPAD_LEFT -> dispatch(AppAction.SeekBackwardLong)
                     KeyEvent.KEYCODE_DPAD_RIGHT -> dispatch(AppAction.SeekForwardLong)
                     KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER -> dispatch(AppAction.ConfirmLong)
+                    KeyEvent.KEYCODE_BACK -> dispatch(AppAction.NavigateHome)
                     in InputPressClassifier.PLAY_PAUSE_KEYS -> dispatch(AppAction.ShowNowPlaying)
                 }
             } else if (longPress && event.repeatCount > 0 &&
@@ -53,6 +54,10 @@ class Y2InputController(
         if (longPressedKeys.remove(keyCode)) return true
 
         val heldForMs = (event.eventTime - event.downTime).coerceAtLeast(0)
+        if (InputPressClassifier.releaseNavigatesHome(keyCode, heldForMs)) {
+            dispatch(AppAction.NavigateHome)
+            return true
+        }
         if (InputPressClassifier.releaseOpensNowPlaying(keyCode, heldForMs) &&
             HardwareKeyGate.isLocalKeypad(event.deviceId)
         ) {
@@ -131,4 +136,7 @@ internal object InputPressClassifier {
 
     fun releaseOpensNowPlaying(keyCode: Int, heldForMs: Long): Boolean =
         keyCode in PLAY_PAUSE_KEYS && heldForMs.coerceAtLeast(0) >= LONG_PRESS_MS
+
+    fun releaseNavigatesHome(keyCode: Int, heldForMs: Long): Boolean =
+        keyCode == KeyEvent.KEYCODE_BACK && heldForMs.coerceAtLeast(0) >= LONG_PRESS_MS
 }

--- a/app/src/test/kotlin/com/schulzcode/y2player/input/InputPressClassifierTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/input/InputPressClassifierTest.kt
@@ -75,14 +75,33 @@ class InputPressClassifierTest {
     }
 
     @Test
-    fun `a long release on a non-play key never navigates`() {
+    fun `a long release on an unrelated key never navigates`() {
         assertFalse(InputPressClassifier.releaseOpensNowPlaying(KeyEvent.KEYCODE_DPAD_CENTER, 5_000))
         assertFalse(InputPressClassifier.releaseOpensNowPlaying(KeyEvent.KEYCODE_BACK, 5_000))
+        assertFalse(InputPressClassifier.releaseNavigatesHome(KeyEvent.KEYCODE_DPAD_CENTER, 5_000))
+    }
+
+    @Test
+    fun `holding the top back button navigates home on release`() {
+        assertFalse(
+            InputPressClassifier.releaseNavigatesHome(
+                KeyEvent.KEYCODE_BACK,
+                InputPressClassifier.LONG_PRESS_MS - 1
+            )
+        )
+        assertTrue(
+            InputPressClassifier.releaseNavigatesHome(
+                KeyEvent.KEYCODE_BACK,
+                InputPressClassifier.LONG_PRESS_MS
+            )
+        )
+        assertFalse(InputPressClassifier.releaseNavigatesHome(KeyEvent.KEYCODE_DPAD_LEFT, 5_000))
     }
 
     @Test
     fun `a negative held time cannot navigate`() {
         assertFalse(InputPressClassifier.releaseOpensNowPlaying(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, -5_000))
+        assertFalse(InputPressClassifier.releaseNavigatesHome(KeyEvent.KEYCODE_BACK, -5_000))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- keep a short top Back-button press as one-level navigation
- route a held Back press directly to the existing `NavigateHome` action
- detect the hold both from Android key repeats and on release for firmware that does not emit repeats
- suppress the short Back action after a recognized hold

## Validation

- `testDebugUnitTest`
- `lintDebug`
- `assembleDebug`

Fixes #95