### PR TITLE
Fix playlist order after disabling shuffle

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/queue/QueueController.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/queue/QueueController.kt
@@ -280,7 +280,8 @@ class QueueController(
     fun toggleShuffle(): Boolean {
         shuffleEnabled = !shuffleEnabled
         if (shuffleEnabled) shuffleSeed = System.nanoTime()
-        reorderFutureContinuation(shuffleEnabled)
+        if (shuffleEnabled) reorderFutureContinuation(shuffled = true)
+        else restoreContinuationOrderFromCurrent()
         return shuffleEnabled
     }
 
@@ -297,7 +298,7 @@ class QueueController(
         if (!changed) return false
         shuffleEnabled = false
         repeatMode = RepeatMode.OFF
-        reorderFutureContinuation(shuffled = false)
+        restoreContinuationOrderFromCurrent()
         return true
     }
 
@@ -356,6 +357,38 @@ class QueueController(
         entries.subList(start, entries.size).clear()
         entries += manual
         entries += continuation
+        touchEntries()
+    }
+
+    /**
+     * Makes the active collection entry the anchor of normal playback again.
+     *
+     * Sorting only the unplayed tail can put an earlier, not-yet-played entry (often track 1)
+     * directly after the current song. Rebuilding the materialized collection keeps the current
+     * entry selected and resumes with its successor, as if that song had been selected without
+     * shuffle. Explicit future Up Next entries still retain priority over the continuation.
+     */
+    private fun restoreContinuationOrderFromCurrent() {
+        val index = currentIndex
+        val currentId = currentEntryId()
+        val current = index?.let(entries::getOrNull)
+        if (index == null || currentId == null || current?.origin != QueueOrigin.CONTINUATION) {
+            reorderFutureContinuation(shuffled = false)
+            return
+        }
+
+        val pastManual = entries.take(index).filter { it.origin == QueueOrigin.UP_NEXT }
+        val futureManual = entries.drop(index + 1).filter { it.origin == QueueOrigin.UP_NEXT }
+        val continuation = entries
+            .filter { it.origin == QueueOrigin.CONTINUATION }
+            .sortedBy { it.sourceOrder ?: Int.MAX_VALUE }
+
+        entries.clear()
+        entries += pastManual
+        entries += continuation
+        currentIndex = entries.indexOfFirst { it.id == currentId }.takeIf { it >= 0 }
+        val insertionIndex = currentIndex?.plus(1) ?: entries.size
+        entries.addAll(insertionIndex, futureManual)
         touchEntries()
     }
 

--- a/app/src/test/kotlin/com/schulzcode/y2player/queue/QueueControllerTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/queue/QueueControllerTest.kt
@@ -83,6 +83,34 @@ class QueueControllerTest {
         assertEquals(listOf(1L, 2L, 3L, 4L, 5L), queue.visibleIds())
     }
 
+    @Test fun disablingShuffleContinuesAfterTheCurrentPlaylistTrack() {
+        val queue = shuffledQueueAt(trackId = 4)
+
+        queue.toggleShuffle()
+
+        assertEquals(4L, queue.currentTrackId())
+        assertEquals(listOf(4L, 5L), queue.visibleIds())
+        assertEquals(5L, queue.next())
+    }
+
+    @Test fun disablingShuffleAtTheLastPlaylistTrackDoesNotRestartAtTrackOne() {
+        val queue = shuffledQueueAt(trackId = 5)
+
+        queue.toggleShuffle()
+
+        assertEquals(listOf(5L), queue.visibleIds())
+        assertNull(queue.next())
+    }
+
+    @Test fun disablingShuffleKeepsFutureUpNextAheadOfTheOrderedContinuation() {
+        val queue = shuffledQueueAt(trackId = 2)
+        queue.addToUpNext(listOf(80, 81))
+
+        queue.toggleShuffle()
+
+        assertEquals(listOf(2L, 80L, 81L, 3L, 4L, 5L), queue.visibleIds())
+    }
+
     @Test fun repeatAllDoesNotRepeatManualEntries() {
         val queue = QueueController(
             initialItems = listOf(1, 2), initialIndex = 0, initialRepeatMode = RepeatMode.ALL
@@ -196,5 +224,23 @@ class QueueControllerTest {
         assertNull(queue.peekNextInCurrentPass())
         assertNull(queue.nextInCurrentPass())
         assertEquals(20L, queue.currentTrackId())
+    }
+
+    private fun shuffledQueueAt(trackId: Long): QueueController {
+        val shuffled = listOf(4L, 2L, 1L, 3L, 5L).map { id ->
+            QueueEntry(id, id, QueueOrigin.CONTINUATION, sourceOrder = id.toInt() - 1)
+        }
+        return QueueController().apply {
+            restore(
+                shuffled,
+                PersistedPlaybackSession(
+                    currentEntryId = trackId,
+                    positionMs = 0,
+                    repeatMode = RepeatMode.OFF,
+                    shuffleEnabled = true,
+                    shuffleSeed = 7
+                )
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- rebuild ordered continuation around the currently playing playlist track when shuffle is disabled
- preserve explicit future Up Next entries ahead of the ordered continuation
- cover progressed shuffle, final-track, and Up Next behavior with regression tests

## Verification
- `ANDROID_SDK_ROOT=/opt/android-sdk bash ./gradlew -PallowStaleNative=true testDebugUnitTest lintDebug assembleDebug`
- Kotlin-only change; the isolated clean worktree does not contain the generated native audio binary, so verification used the repository's explicit stale-native allowance

Fixes #93