### PR TITLE
Prevent wake-up seek holds from skipping chapters

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/input/HardwareKeyGate.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/input/HardwareKeyGate.kt
@@ -86,6 +86,28 @@ object HardwareKeyGate {
         device.hasKeys(KeyEvent.KEYCODE_BACK, KeyEvent.KEYCODE_DPAD_UP).any { it }
     }.getOrDefault(false)
 
+    /** The activity owns local keypad gestures whenever it can receive them. */
+    fun shouldDeferLocalBroadcastToActivity(
+        context: Context,
+        source: Source,
+        fromLocalKeypad: Boolean
+    ): Boolean {
+        val state = screenState(context)
+        return shouldDeferLocalBroadcastToActivity(
+            source,
+            fromLocalKeypad,
+            state.screenOn,
+            state.keyguardLocked
+        )
+    }
+
+    internal fun shouldDeferLocalBroadcastToActivity(
+        source: Source,
+        fromLocalKeypad: Boolean,
+        screenOn: Boolean,
+        keyguardLocked: Boolean
+    ): Boolean = source == Source.Y2_BROADCAST && fromLocalKeypad && screenOn && !keyguardLocked
+
     @Synchronized
     fun invalidateScreenState() {
         cachedScreenState = null

--- a/app/src/main/kotlin/com/schulzcode/y2player/playback/MediaButtonReceiver.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/playback/MediaButtonReceiver.kt
@@ -28,6 +28,12 @@ class MediaButtonReceiver : BroadcastReceiver() {
             scanCode = event.scanCode,
             fromLocalKeypad = fromLocalKeypad
         ) ?: return logRejected(context, "unmapped_key", source, event)
+        // The vendor rebroadcasts the same physical keypad stream delivered to the foreground
+        // activity. Letting that fallback path act while the display is usable turns the first
+        // edge of a hold into Previous/Next before the activity can classify it as a seek.
+        if (HardwareKeyGate.shouldDeferLocalBroadcastToActivity(context, source, fromLocalKeypad)) {
+            return logRejected(context, "activity_owns_local_key", source, event)
+        }
         val localKeysWhileScreenOff = (context.applicationContext as? Y2Application)
             ?.container?.preferences?.snapshot()?.localKeysWhileScreenOff ?: false
         if (!serviceRequest.isVolumeAdjustment && !HardwareKeyGate.isInputAllowed(

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/MainActivity.kt
@@ -101,6 +101,7 @@ class MainActivity : Activity() {
     private val screenStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             playbackBinder?.cancelVolumeKeyRepeat()
+            HardwareKeyGate.invalidateScreenState()
             when (intent?.action) {
                 Intent.ACTION_SCREEN_OFF -> playerView.setTextAnimationsVisible(false)
                 Intent.ACTION_SCREEN_ON -> playerView.setTextAnimationsVisible(true)
@@ -300,6 +301,7 @@ class MainActivity : Activity() {
 
     override fun onResume() {
         super.onResume()
+        HardwareKeyGate.invalidateScreenState()
         eventLog.debug(Sub.ACTIVITY, Ev.ACTIVITY_RESUME)
         val currentPreferences = preferences.snapshot()
         val systemHaptics = systemHapticsController.suppress()

--- a/app/src/test/kotlin/com/schulzcode/y2player/input/HardwareKeyGateTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/input/HardwareKeyGateTest.kt
@@ -238,6 +238,38 @@ class HardwareKeyGateTest {
         )
     }
 
+    @Test fun unlockedActivityOwnsLocalVendorBroadcasts() {
+        assertTrue(HardwareKeyGate.shouldDeferLocalBroadcastToActivity(
+            HardwareKeyGate.Source.Y2_BROADCAST,
+            fromLocalKeypad = true,
+            screenOn = true,
+            keyguardLocked = false
+        ))
+        assertFalse(HardwareKeyGate.shouldDeferLocalBroadcastToActivity(
+            HardwareKeyGate.Source.Y2_BROADCAST,
+            fromLocalKeypad = true,
+            screenOn = false,
+            keyguardLocked = true
+        ))
+    }
+
+    @Test fun remoteAndFrameworkMediaBroadcastsNeverDeferToTheActivity() {
+        listOf(HardwareKeyGate.Source.MEDIA_BROADCAST, HardwareKeyGate.Source.Y2_BROADCAST).forEach { source ->
+            assertFalse(HardwareKeyGate.shouldDeferLocalBroadcastToActivity(
+                source,
+                fromLocalKeypad = false,
+                screenOn = true,
+                keyguardLocked = false
+            ))
+        }
+        assertFalse(HardwareKeyGate.shouldDeferLocalBroadcastToActivity(
+            HardwareKeyGate.Source.MEDIA_BROADCAST,
+            fromLocalKeypad = true,
+            screenOn = true,
+            keyguardLocked = false
+        ))
+    }
+
     @Test fun screenOffHeadsetTransportIsAllowedOnBothChannels() {
         listOf(HardwareKeyGate.Source.MEDIA_BROADCAST, HardwareKeyGate.Source.Y2_BROADCAST).forEach { source ->
             transportKeys.forEach { keyCode ->


### PR DESCRIPTION
## Summary
- give the unlocked foreground activity exclusive ownership of local keypad gestures
- keep vendor broadcasts as the screen-off fallback without affecting remote media controls
- invalidate cached display state on screen and activity resume boundaries
- add regression coverage for local, remote, and framework broadcast ownership

## Verification
- `ANDROID_SDK_ROOT=/opt/android-sdk bash ./gradlew -PallowStaleNative=true testDebugUnitTest lintDebug assembleDebug`
- Kotlin-only change; the isolated worktree lacks the generated native audio binary, so verification used the repository's explicit stale-native allowance

Fixes #98