### PR TITLE
Keep screen-off playback awake across track handoffs

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackService.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackService.kt
@@ -254,6 +254,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
     private lateinit var eventLog: EventLog
     private lateinit var storageMonitor: StorageMonitor
     private lateinit var routeMonitor: AudioRouteMonitor
+    private lateinit var playbackWakeLock: PlaybackWakeLock
 
     @Volatile private var snapshot = PlaybackSnapshot()
     @Volatile private var currentTrack: Track? = null
@@ -343,6 +344,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
         )
         storageMonitor = container.storageMonitor
         audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        playbackWakeLock = PlaybackWakeLock(this)
 
         playbackThread = HandlerThread("y2-playback").apply { start() }
         playbackHandler = Handler(playbackThread.looper)
@@ -458,6 +460,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
 
     override fun onDestroy() {
         shuttingDown = true
+        if (::playbackWakeLock.isInitialized) playbackWakeLock.release()
         volumeModeTransitionGate.cancel()
         volumeKeyRepeatController.cancel()
         if (::libraryRepository.isInitialized) libraryRepository.setPlaybackActive(false)
@@ -2193,6 +2196,7 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
 
     private fun publishSnapshot() {
         val value = snapshot
+        playbackWakeLock.sync(value.status)
         libraryRepository.setPlaybackActive(value.status == PlaybackStatus.PLAYING)
         if (::remoteControl.isInitialized) remoteControl.update(value, currentTrack)
         mainHandler.post {

--- a/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackWakeLock.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackWakeLock.kt
@@ -1,0 +1,30 @@
+package com.schulzcode.y2player.playback
+
+import android.content.Context
+import android.os.PowerManager
+import com.schulzcode.y2player.core.model.PlaybackStatus
+
+internal object PlaybackWakeLockPolicy {
+    fun shouldHold(status: PlaybackStatus): Boolean =
+        status == PlaybackStatus.PREPARING || status == PlaybackStatus.PLAYING
+}
+
+/** Keeps the CPU awake across decoder-to-service handoffs while the display is asleep. */
+internal class PlaybackWakeLock(context: Context) {
+    private val wakeLock = (context.applicationContext
+        .getSystemService(Context.POWER_SERVICE) as PowerManager)
+        .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Y2Player:PlaybackService")
+        .apply { setReferenceCounted(false) }
+
+    fun sync(status: PlaybackStatus) {
+        val required = PlaybackWakeLockPolicy.shouldHold(status)
+        when {
+            required && !wakeLock.isHeld -> wakeLock.acquire()
+            !required && wakeLock.isHeld -> wakeLock.release()
+        }
+    }
+
+    fun release() {
+        if (wakeLock.isHeld) wakeLock.release()
+    }
+}

--- a/app/src/test/kotlin/com/schulzcode/y2player/playback/PlaybackWakeLockTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/playback/PlaybackWakeLockTest.kt
@@ -1,0 +1,19 @@
+package com.schulzcode.y2player.playback
+
+import com.schulzcode.y2player.core.model.PlaybackStatus
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackWakeLockTest {
+    @Test fun activePlaybackAndPreparationKeepTheCpuAwake() {
+        assertTrue(PlaybackWakeLockPolicy.shouldHold(PlaybackStatus.PREPARING))
+        assertTrue(PlaybackWakeLockPolicy.shouldHold(PlaybackStatus.PLAYING))
+    }
+
+    @Test fun inactiveStatesReleaseTheServiceWakeLock() {
+        listOf(PlaybackStatus.IDLE, PlaybackStatus.PAUSED, PlaybackStatus.ERROR).forEach { status ->
+            assertFalse("$status must not retain the service wake lock", PlaybackWakeLockPolicy.shouldHold(status))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- hold a service-level partial wake lock for the complete PREPARING/PLAYING session
- cover decoder-to-service and next-track handoff gaps while the display is asleep
- release the lock for idle, paused, error, and service teardown states
- add policy regression tests for active and inactive playback states

## Evidence
The issue log stalls at natural track completion with the UI unbound and resumes only when the screen wakes. The engine-level wake lock can be released on READY before the asynchronous service continuation runs; the service-level lock closes that gap.

## Verification
- `ANDROID_SDK_ROOT=/opt/android-sdk bash ./gradlew -PallowStaleNative=true testDebugUnitTest lintDebug assembleDebug`
- Kotlin-only change; the isolated worktree lacks the generated native audio binary, so verification used the repository's explicit stale-native allowance

Fixes #74