### PR TITLE
Add exact-minute sleep timer selection

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/core/model/PlaybackModels.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/model/PlaybackModels.kt
@@ -95,16 +95,12 @@ enum class PlaybackExitReason(val code: String) {
     UNKNOWN("unknown")
 }
 
-enum class SleepTimerMode(val label: String, val durationMs: Long? = null) {
+enum class SleepTimerMode(val label: String) {
     OFF("Off"),
-    MINUTES_15("15 minutes", 15 * 60_000L),
-    MINUTES_30("30 minutes", 30 * 60_000L),
-    MINUTES_60("60 minutes", 60 * 60_000L),
+    MINUTES("Minutes"),
     END_TRACK("End of track"),
     END_ALBUM("End of album"),
-    END_QUEUE("End of queue");
-
-    fun next(): SleepTimerMode = values()[(ordinal + 1) % values().size]
+    END_QUEUE("End of queue")
 }
 
 data class AudioEffectsState(
@@ -142,6 +138,7 @@ data class PlaybackSnapshot(
     val pauseReason: PauseReason = PauseReason.NONE,
     val errorMessage: String? = null,
     val sleepTimerMode: SleepTimerMode = SleepTimerMode.OFF,
+    val sleepTimerConfiguredMinutes: Int? = null,
     val sleepTimerDeadlineElapsedMs: Long? = null,
     val sleepTimerRemainingMs: Long? = null,
     val outputRoute: AudioOutputRoute = AudioOutputRoute.UNKNOWN,

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppAction.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppAction.kt
@@ -3,6 +3,7 @@ package com.schulzcode.y2player.core.state
 import com.schulzcode.y2player.core.model.LibraryState
 import com.schulzcode.y2player.core.model.AlbumSortOrder
 import com.schulzcode.y2player.core.model.PlaybackSnapshot
+import com.schulzcode.y2player.core.model.SleepTimerMode
 import com.schulzcode.y2player.core.model.TrackSortOrder
 import com.schulzcode.y2player.core.model.YearSortOrder
 import com.schulzcode.y2player.diagnostics.DiagnosticsState
@@ -104,7 +105,7 @@ sealed interface AppEffect {
     data object CycleReplayGain : AppEffect
     data object CycleHapticLevel : AppEffect
     data object ToggleWrapLists : AppEffect
-    data object CycleSleepTimer : AppEffect
+    data class SetSleepTimer(val mode: SleepTimerMode, val minutes: Int? = null) : AppEffect
     data object CycleAudioQuality : AppEffect
     data object ToggleAudioEffects : AppEffect
     data object CycleEqualizerPreset : AppEffect

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
@@ -4,6 +4,7 @@ import com.schulzcode.y2player.core.model.PlaybackStatus
 import com.schulzcode.y2player.core.model.TrackSortOrder
 import com.schulzcode.y2player.core.model.AlbumSortOrder
 import com.schulzcode.y2player.core.model.LibraryScope
+import com.schulzcode.y2player.core.model.SleepTimerMode
 import com.schulzcode.y2player.core.model.YearSortOrder
 import com.schulzcode.y2player.core.state.AppEffect.*
 import com.schulzcode.y2player.core.state.ScreenRow.Action
@@ -151,6 +152,7 @@ object AppReducer {
                 else -> Reduction(state)
             }
             Screen.NowPlayingOptions -> confirmNowPlayingOptions(state, row)
+            Screen.SleepTimer -> confirmSleepTimer(state, row)
             Screen.Audio -> confirmAudio(state, row)
             Screen.Settings -> confirmSettings(state, row)
             Screen.PlaybackTransitions, Screen.PlaybackSeeking, Screen.PlaybackVolume,
@@ -792,7 +794,11 @@ object AppReducer {
         return when {
             key == "shuffle" -> Reduction(state, listOf(ToggleShuffle))
             key == "repeat" -> Reduction(state, listOf(CycleRepeat))
-            key == "sleep_timer" -> Reduction(state, listOf(CycleSleepTimer))
+            key == "sleep_timer" -> push(
+                state,
+                Screen.SleepTimer,
+                selectedIndex = ScreenContent.sleepTimerSelectionIndex(state)
+            )
             key == "queue" -> push(state, Screen.Queue, selectedIndex = 1)
             key.startsWith("np_audiobook_chapters:") ->
                 push(state, Screen.AudiobookChapters(key.substringAfter(':')))
@@ -814,6 +820,22 @@ object AppReducer {
             }
             else -> Reduction(state)
         }
+    }
+
+    private fun confirmSleepTimer(state: AppState, row: ScreenRow): Reduction {
+        val key = (row as? Action)?.key ?: return Reduction(state)
+        val effect = when {
+            key == "sleep_timer_off" -> SetSleepTimer(SleepTimerMode.OFF)
+            key == "sleep_timer_end_track" -> SetSleepTimer(SleepTimerMode.END_TRACK)
+            key == "sleep_timer_end_album" -> SetSleepTimer(SleepTimerMode.END_ALBUM)
+            key == "sleep_timer_end_queue" -> SetSleepTimer(SleepTimerMode.END_QUEUE)
+            key.startsWith("sleep_timer_minutes:") -> {
+                val minutes = key.substringAfter(':').toIntOrNull() ?: return Reduction(state)
+                SetSleepTimer(SleepTimerMode.MINUTES, minutes)
+            }
+            else -> return Reduction(state)
+        }
+        return Reduction(pop(state), listOf(effect))
     }
 
     private fun playSelected(state: AppState): Reduction {

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/Screen.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/Screen.kt
@@ -50,6 +50,7 @@ sealed interface Screen {
     data object QueueManagement : Screen
     data object NowPlaying : Screen
     data object NowPlayingOptions : Screen
+    data object SleepTimer : Screen
     data object Queue : Screen
     data object Audio : Screen
     data object Settings : Screen
@@ -127,6 +128,7 @@ val Screen.code: String get() = when (this) {
     Screen.QueueManagement -> "queue_management"
     Screen.NowPlaying -> "now_playing"
     Screen.NowPlayingOptions -> "now_playing_options"
+    Screen.SleepTimer -> "sleep_timer"
     Screen.Queue -> "queue"
     Screen.Audio -> "audio"
     Screen.Settings -> "settings"

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/ScreenContent.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/ScreenContent.kt
@@ -11,6 +11,7 @@ import com.schulzcode.y2player.core.model.CodecSupport
 import com.schulzcode.y2player.core.model.LibraryScope
 import com.schulzcode.y2player.core.model.NaturalTextOrder
 import com.schulzcode.y2player.core.model.RepeatMode
+import com.schulzcode.y2player.core.model.SleepTimerMode
 import com.schulzcode.y2player.core.model.QueueEntry
 import com.schulzcode.y2player.core.model.QueueOrigin
 import com.schulzcode.y2player.core.model.Track
@@ -122,6 +123,7 @@ object ScreenContent {
         Screen.QueueManagement -> "Queue"
         Screen.NowPlaying -> "Now Playing"
         Screen.NowPlayingOptions -> "Playback Options"
+        Screen.SleepTimer -> "Sleep Timer"
         Screen.Queue -> "Queue"
         Screen.Audio -> "Audio"
         Screen.Settings -> "Settings"
@@ -223,6 +225,7 @@ object ScreenContent {
         Screen.Queue -> queueRows(state)
         Screen.NowPlaying -> emptyList()
         Screen.NowPlayingOptions -> nowPlayingOptionsRows(state)
+        Screen.SleepTimer -> sleepTimerRows(state)
         Screen.Audio -> audioRows(state)
         Screen.Settings -> settingsRows(state)
         Screen.PlaybackTransitions -> playbackTransitionRows(state)
@@ -706,6 +709,33 @@ object ScreenContent {
                 add(ScreenRow.Action("Track Options", track.title, "np_track_options:${track.id}"))
             }
         }
+    }
+
+    private fun sleepTimerRows(state: AppState): List<ScreenRow> = buildList {
+        fun addChoice(title: String, key: String, active: Boolean) {
+            add(ScreenRow.Action(title, if (active) "Active" else null, key))
+        }
+        val playback = state.playback
+        addChoice("Off", "sleep_timer_off", playback.sleepTimerMode == SleepTimerMode.OFF)
+        addChoice("End of track", "sleep_timer_end_track", playback.sleepTimerMode == SleepTimerMode.END_TRACK)
+        addChoice("End of album", "sleep_timer_end_album", playback.sleepTimerMode == SleepTimerMode.END_ALBUM)
+        addChoice("End of queue", "sleep_timer_end_queue", playback.sleepTimerMode == SleepTimerMode.END_QUEUE)
+        for (minutes in 1..60) {
+            addChoice(
+                if (minutes == 1) "1 minute" else "$minutes minutes",
+                "sleep_timer_minutes:$minutes",
+                playback.sleepTimerMode == SleepTimerMode.MINUTES &&
+                    playback.sleepTimerConfiguredMinutes == minutes
+            )
+        }
+    }
+
+    fun sleepTimerSelectionIndex(state: AppState): Int = when (state.playback.sleepTimerMode) {
+        SleepTimerMode.OFF -> 0
+        SleepTimerMode.END_TRACK -> 1
+        SleepTimerMode.END_ALBUM -> 2
+        SleepTimerMode.END_QUEUE -> 3
+        SleepTimerMode.MINUTES -> 3 + (state.playback.sleepTimerConfiguredMinutes ?: 5).coerceIn(1, 60)
     }
 
     private fun playingNextLabel(state: AppState): String {

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/SleepTimerPresentation.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/SleepTimerPresentation.kt
@@ -16,7 +16,7 @@ internal object SleepTimerPresentation {
     }
 
     fun label(mode: SleepTimerMode, remainingMs: Long?): String =
-        if (mode.durationMs != null && remainingMs != null) countdown(remainingMs) else mode.label
+        if (mode == SleepTimerMode.MINUTES && remainingMs != null) countdown(remainingMs) else mode.label
 
     fun shouldRefresh(
         screen: Screen,
@@ -24,5 +24,5 @@ internal object SleepTimerPresentation {
         deadlineElapsedMs: Long?,
         uiVisible: Boolean
     ): Boolean = uiVisible && screen == Screen.NowPlayingOptions &&
-        mode.durationMs != null && deadlineElapsedMs != null
+        mode == SleepTimerMode.MINUTES && deadlineElapsedMs != null
 }

--- a/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackService.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/playback/PlaybackService.kt
@@ -157,7 +157,8 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
             afterQueueMutation()
         }
 
-        fun cycleSleepTimer() = post(::cycleSleepTimerInternal)
+        fun setSleepTimer(mode: SleepTimerMode, minutes: Int? = null) =
+            post { setSleepTimerInternal(mode, minutes) }
 
         fun applyPreferences(value: PlayerPreferencesState) = post {
             applyPreferencesInternal(value)
@@ -1749,10 +1750,10 @@ class PlaybackService : Service(), PlaybackEngine.Listener, AudioFocusController
         return engine.durationMs().takeIf { it > 0 } ?: snapshot.durationMs
     }
 
-    private fun cycleSleepTimerInternal() {
+    private fun setSleepTimerInternal(mode: SleepTimerMode, minutes: Int?) {
         sleepTimerCallback?.let(playbackHandler::removeCallbacks)
         sleepTimerCallback = null
-        sleepTimer.cycle(SystemClock.elapsedRealtime())?.let { scheduled ->
+        sleepTimer.set(mode, minutes, SystemClock.elapsedRealtime())?.let { scheduled ->
             val callback = object : Runnable {
                 override fun run() {
                     when (val tick = sleepTimer.onTimer(scheduled.generation, SystemClock.elapsedRealtime())) {

--- a/app/src/main/kotlin/com/schulzcode/y2player/playback/SleepTimerController.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/playback/SleepTimerController.kt
@@ -19,12 +19,18 @@ internal class SleepTimerController {
 
     var mode: SleepTimerMode = SleepTimerMode.OFF
         private set
+    var configuredMinutes: Int? = null
+        private set
     var deadlineElapsedMs: Long? = null
         private set
 
-    fun cycle(nowElapsedMs: Long): ScheduledSleepTimer? {
-        mode = mode.next()
-        deadlineElapsedMs = mode.durationMs?.let { nowElapsedMs + it }
+    fun set(mode: SleepTimerMode, minutes: Int?, nowElapsedMs: Long): ScheduledSleepTimer? {
+        val safeMinutes = if (mode == SleepTimerMode.MINUTES) {
+            (minutes ?: DEFAULT_MINUTES).coerceIn(MIN_MINUTES, MAX_MINUTES)
+        } else null
+        this.mode = mode
+        configuredMinutes = safeMinutes.takeIf { mode == SleepTimerMode.MINUTES }
+        deadlineElapsedMs = configuredMinutes?.let { nowElapsedMs + it * 60_000L }
         val value = generation.advance()
         return deadlineElapsedMs?.let { deadline ->
             ScheduledSleepTimer(value, (deadline - nowElapsedMs).coerceAtLeast(1L))
@@ -43,12 +49,20 @@ internal class SleepTimerController {
     fun clear() {
         generation.advance()
         mode = SleepTimerMode.OFF
+        configuredMinutes = null
         deadlineElapsedMs = null
     }
 
     fun applyTo(snapshot: PlaybackSnapshot, nowElapsedMs: Long): PlaybackSnapshot = snapshot.copy(
         sleepTimerMode = mode,
+        sleepTimerConfiguredMinutes = configuredMinutes,
         sleepTimerDeadlineElapsedMs = deadlineElapsedMs,
         sleepTimerRemainingMs = deadlineElapsedMs?.let { (it - nowElapsedMs).coerceAtLeast(0L) }
     )
+
+    companion object {
+        const val MIN_MINUTES = 1
+        const val MAX_MINUTES = 60
+        const val DEFAULT_MINUTES = 5
+    }
 }

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/MainActivity.kt
@@ -516,7 +516,7 @@ class MainActivity : Activity() {
             AppEffect.ToggleWrapLists -> applyPlaybackPreferences(preferences.toggleWrapLists())
             AppEffect.CycleVolumeMode -> cycleVolumeMode()
             AppEffect.CycleReplayGain -> applyPlaybackPreferences(preferences.cycleReplayGain())
-            AppEffect.CycleSleepTimer -> requirePlayback { it.cycleSleepTimer() }
+            is AppEffect.SetSleepTimer -> requirePlayback { it.setSleepTimer(effect.mode, effect.minutes) }
             AppEffect.CycleAudioQuality -> {
                 val value = preferences.cycleAudioQuality()
                 applyPlaybackPreferences(value)

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2RowIcons.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2RowIcons.kt
@@ -159,6 +159,7 @@ object Y2RowIcons {
         key.startsWith("sort:") -> Y2Icon.SORT
         key.startsWith("balance:") -> Y2Icon.VOLUME
         key.startsWith("brightness:") || key.startsWith("timeout:") -> Y2Icon.DISPLAY
+        key.startsWith("sleep_timer_") -> Y2Icon.TIMER
         key.startsWith("eq_band:") -> Y2Icon.EQUALIZER
         else -> Y2Icon.ACTION
     }

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerNowPlayingTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerNowPlayingTest.kt
@@ -3,6 +3,7 @@ package com.schulzcode.y2player.core.state
 import com.schulzcode.y2player.core.model.LibraryState
 import com.schulzcode.y2player.core.model.PlaybackSnapshot
 import com.schulzcode.y2player.core.model.RepeatMode
+import com.schulzcode.y2player.core.model.SleepTimerMode
 import com.schulzcode.y2player.core.model.Track
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -123,10 +124,43 @@ class AppReducerNowPlayingTest {
         assertTrue("track-list options keep Add to Playlist", "track_playlist:1" in keys)
     }
 
-    @Test fun optionsMenuTogglesShuffleAndRepeat() {
+    @Test fun optionsMenuTogglesShuffleAndRepeatAndOpensTheSleepTimer() {
         assertEquals(AppEffect.ToggleShuffle, optionsReductionFor("shuffle").effects.single())
         assertEquals(AppEffect.CycleRepeat, optionsReductionFor("repeat").effects.single())
-        assertEquals(AppEffect.CycleSleepTimer, optionsReductionFor("sleep_timer").effects.single())
+        val sleepTimer = optionsReductionFor("sleep_timer")
+        assertEquals(Screen.SleepTimer, sleepTimer.state.currentScreen)
+        assertTrue(sleepTimer.effects.isEmpty())
+    }
+
+    @Test fun sleepTimerOffersEveryMinuteAndAppliesTheSelectedValue() {
+        val opened = optionsReductionFor("sleep_timer").state
+        val rows = ScreenContent.rows(opened).filterIsInstance<ScreenRow.Action>()
+        assertEquals(64, rows.size)
+        assertEquals("sleep_timer_minutes:1", rows[4].key)
+        assertEquals("sleep_timer_minutes:60", rows.last().key)
+
+        val selected = opened.copy(
+            screenStack = opened.screenStack.dropLast(1) + opened.currentEntry.copy(selectedIndex = 8)
+        )
+        val applied = AppReducer.reduce(selected, AppAction.Confirm)
+
+        assertEquals(Screen.NowPlayingOptions, applied.state.currentScreen)
+        assertEquals(AppEffect.SetSleepTimer(SleepTimerMode.MINUTES, 5), applied.effects.single())
+    }
+
+    @Test fun reopeningSleepTimerSelectsTheActiveMinute() {
+        val state = optionsState().copy(playback = optionsState().playback.copy(
+            sleepTimerMode = SleepTimerMode.MINUTES,
+            sleepTimerConfiguredMinutes = 7
+        ))
+        val index = ScreenContent.rows(state).indexOfFirst { (it as? ScreenRow.Action)?.key == "sleep_timer" }
+        val opened = AppReducer.reduce(
+            state.copy(screenStack = state.screenStack.dropLast(1) + state.currentEntry.copy(selectedIndex = index)),
+            AppAction.Confirm
+        ).state
+
+        assertEquals(10, opened.selectedIndex)
+        assertEquals("Active", (ScreenContent.rows(opened)[10] as ScreenRow.Action).subtitle)
     }
 
     @Test fun optionsMenuTogglesFavoriteOfTheCurrentTrack() {

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/ScreenCatalogue.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/ScreenCatalogue.kt
@@ -47,6 +47,7 @@ object ScreenCatalogue {
         put(Screen.QueueManagement)
         put(Screen.NowPlaying)
         put(Screen.NowPlayingOptions)
+        put(Screen.SleepTimer)
         put(Screen.Queue)
         put(Screen.Audio)
         put(Screen.Settings)

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/SleepTimerPresentationTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/SleepTimerPresentationTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 class SleepTimerPresentationTest {
     @Test fun fifteenMinuteTimerInitiallyDisplaysFifteenMinutes() {
         val timer = SleepTimerController()
-        timer.cycle(10_000L)
+        timer.set(SleepTimerMode.MINUTES, 15, 10_000L)
         val snapshot = timer.applyTo(PlaybackSnapshot(), 10_001L)
         val remaining = SleepTimerPresentation.remainingMs(snapshot, 10_001L)
 
@@ -30,7 +30,8 @@ class SleepTimerPresentationTest {
 
     @Test fun remainingTimeIsAlwaysDerivedFromTheDeadline() {
         val snapshot = PlaybackSnapshot(
-            sleepTimerMode = SleepTimerMode.MINUTES_15,
+            sleepTimerMode = SleepTimerMode.MINUTES,
+            sleepTimerConfiguredMinutes = 15,
             sleepTimerDeadlineElapsedMs = 901_000L,
             sleepTimerRemainingMs = 123L
         )
@@ -51,13 +52,13 @@ class SleepTimerPresentationTest {
     @Test fun refreshRunsOnlyWhileANumericCountdownIsVisible() {
         assertTrue(SleepTimerPresentation.shouldRefresh(
             Screen.NowPlayingOptions,
-            SleepTimerMode.MINUTES_15,
+            SleepTimerMode.MINUTES,
             deadlineElapsedMs = 900_000L,
             uiVisible = true
         ))
         assertFalse(SleepTimerPresentation.shouldRefresh(
             Screen.NowPlaying,
-            SleepTimerMode.MINUTES_15,
+            SleepTimerMode.MINUTES,
             deadlineElapsedMs = 900_000L,
             uiVisible = true
         ))
@@ -69,7 +70,7 @@ class SleepTimerPresentationTest {
         ))
         assertFalse(SleepTimerPresentation.shouldRefresh(
             Screen.NowPlayingOptions,
-            SleepTimerMode.MINUTES_15,
+            SleepTimerMode.MINUTES,
             deadlineElapsedMs = 900_000L,
             uiVisible = false
         ))

--- a/app/src/test/kotlin/com/schulzcode/y2player/playback/SleepTimerControllerTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/playback/SleepTimerControllerTest.kt
@@ -9,106 +9,70 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SleepTimerControllerTest {
-    @Test fun activeTimerExpiresBeforeThePlaybackStopPathRuns() {
+    @Test fun customMinuteTimerExpiresBeforeThePlaybackStopPathRuns() {
         val timer = SleepTimerController()
-        val scheduled = requireNotNull(timer.cycle(1_000L))
+        val scheduled = requireNotNull(timer.set(SleepTimerMode.MINUTES, 5, 1_000L))
 
-        assertEquals(
-            SleepTimerTick.Expired,
-            timer.onTimer(scheduled.generation, 1_000L + requireNotNull(timer.mode.durationMs))
-        )
+        assertEquals(SleepTimerTick.Expired, timer.onTimer(scheduled.generation, 301_000L))
         assertEquals(SleepTimerMode.OFF, timer.mode)
         assertNull(timer.deadlineElapsedMs)
 
-        val source = playbackServiceSource()
-        val expiry = source.substringAfter("SleepTimerTick.Expired ->")
+        val expiry = playbackServiceSource().substringAfter("SleepTimerTick.Expired ->")
             .substringBefore("is SleepTimerTick.Waiting")
         assertTrue(expiry.indexOf("syncSleepTimerSnapshot()") < expiry.indexOf("pauseInternal(PauseReason.SLEEP_TIMER)"))
     }
 
-    @Test fun expiredTimerIsInactiveInThePublishedSnapshot() {
+    @Test fun snapshotPublishesTheConfiguredMinutesAndDeadline() {
         val timer = SleepTimerController()
-        val scheduled = requireNotNull(timer.cycle(0L))
-        val deadline = requireNotNull(timer.deadlineElapsedMs)
-        val active = timer.applyTo(PlaybackSnapshot(), 1L)
-        assertEquals(SleepTimerMode.MINUTES_15, active.sleepTimerMode)
+        timer.set(SleepTimerMode.MINUTES, 7, 10_000L)
+        val snapshot = timer.applyTo(PlaybackSnapshot(), 10_001L)
 
-        timer.onTimer(scheduled.generation, deadline)
-        val expired = timer.applyTo(active, deadline)
-
-        assertEquals(SleepTimerMode.OFF, expired.sleepTimerMode)
-        assertNull(expired.sleepTimerRemainingMs)
+        assertEquals(SleepTimerMode.MINUTES, snapshot.sleepTimerMode)
+        assertEquals(7, snapshot.sleepTimerConfiguredMinutes)
+        assertEquals(419_999L, snapshot.sleepTimerRemainingMs)
     }
 
-    @Test fun manuallyCancelledTimerStaysOffAndCannotBeRestoredByItsCallback() {
+    @Test fun minuteInputIsClampedToTheSupportedWheelRange() {
         val timer = SleepTimerController()
-        val cancelled = requireNotNull(timer.cycle(10L))
+        timer.set(SleepTimerMode.MINUTES, 0, 0L)
+        assertEquals(1, timer.configuredMinutes)
+        assertEquals(60_000L, timer.deadlineElapsedMs)
 
-        repeat(SleepTimerMode.values().size - 1) { timer.cycle(20L + it) }
-
-        assertEquals(SleepTimerMode.OFF, timer.mode)
-        assertNull(timer.deadlineElapsedMs)
-        assertEquals(
-            SleepTimerTick.Stale,
-            timer.onTimer(cancelled.generation, 10L + requireNotNull(SleepTimerMode.MINUTES_15.durationMs))
-        )
-        assertEquals(SleepTimerMode.OFF, timer.mode)
+        timer.set(SleepTimerMode.MINUTES, 99, 0L)
+        assertEquals(60, timer.configuredMinutes)
+        assertEquals(3_600_000L, timer.deadlineElapsedMs)
     }
 
-    @Test fun trackAlbumAndQueueModesRemainBoundaryBasedAndClearAfterStopping() {
-        listOf(SleepTimerMode.END_TRACK, SleepTimerMode.END_ALBUM, SleepTimerMode.END_QUEUE).forEach { target ->
+    @Test fun boundaryModesDoNotScheduleCallbacksAndClearNormally() {
+        listOf(SleepTimerMode.END_TRACK, SleepTimerMode.END_ALBUM, SleepTimerMode.END_QUEUE).forEach { mode ->
             val timer = SleepTimerController()
-            var scheduled: ScheduledSleepTimer? = null
-            repeat(target.ordinal) { scheduled = timer.cycle(it.toLong()) }
-
-            assertEquals(target, timer.mode)
-            assertNull(scheduled)
+            assertNull(timer.set(mode, null, 0L))
+            assertEquals(mode, timer.mode)
             assertNull(timer.deadlineElapsedMs)
-
             timer.clear()
             assertEquals(SleepTimerMode.OFF, timer.mode)
         }
     }
 
-    @Test fun aNewTimerWorksAfterThePreviousTimerExpired() {
+    @Test fun replacingOrClearingATimerInvalidatesItsOldCallback() {
         val timer = SleepTimerController()
-        val first = requireNotNull(timer.cycle(0L))
-        timer.onTimer(first.generation, requireNotNull(timer.mode.durationMs))
+        val old = requireNotNull(timer.set(SleepTimerMode.MINUTES, 5, 0L))
+        val replacement = requireNotNull(timer.set(SleepTimerMode.MINUTES, 10, 500L))
 
-        val secondStartedAt = 2_000_000L
-        val second = requireNotNull(timer.cycle(secondStartedAt))
-        assertEquals(SleepTimerMode.MINUTES_15, timer.mode)
-        assertEquals(
-            SleepTimerTick.Expired,
-            timer.onTimer(second.generation, secondStartedAt + requireNotNull(timer.mode.durationMs))
-        )
-        assertEquals(SleepTimerMode.OFF, timer.mode)
+        assertEquals(SleepTimerTick.Stale, timer.onTimer(old.generation, 300_000L))
+        assertEquals(SleepTimerTick.Expired, timer.onTimer(replacement.generation, 600_500L))
+
+        val cancelled = requireNotNull(timer.set(SleepTimerMode.MINUTES, 2, 0L))
+        timer.set(SleepTimerMode.OFF, null, 1L)
+        assertEquals(SleepTimerTick.Stale, timer.onTimer(cancelled.generation, 120_000L))
     }
 
-    @Test fun replacingATimerInvalidatesTheOldCallbackAndKeepsTheNewDeadline() {
+    @Test fun earlyCallbackIsRescheduled() {
         val timer = SleepTimerController()
-        val old = requireNotNull(timer.cycle(0L))
-        val replacementStartedAt = 500L
-        val replacement = requireNotNull(timer.cycle(replacementStartedAt))
-
-        assertEquals(SleepTimerMode.MINUTES_30, timer.mode)
-        assertEquals(SleepTimerTick.Stale, timer.onTimer(old.generation, requireNotNull(SleepTimerMode.MINUTES_15.durationMs)))
-        assertEquals(
-            SleepTimerTick.Expired,
-            timer.onTimer(replacement.generation, replacementStartedAt + requireNotNull(SleepTimerMode.MINUTES_30.durationMs))
-        )
-    }
-
-    @Test fun anEarlyCallbackIsRescheduledInsteadOfLeavingAnElapsedTimerActive() {
-        val timer = SleepTimerController()
-        val scheduled = requireNotNull(timer.cycle(1_000L))
+        val scheduled = requireNotNull(timer.set(SleepTimerMode.MINUTES, 1, 1_000L))
         val deadline = requireNotNull(timer.deadlineElapsedMs)
 
-        assertEquals(
-            SleepTimerTick.Waiting(1L),
-            timer.onTimer(scheduled.generation, deadline - 1L)
-        )
-        assertEquals(SleepTimerMode.MINUTES_15, timer.mode)
+        assertEquals(SleepTimerTick.Waiting(1L), timer.onTimer(scheduled.generation, deadline - 1L))
         assertEquals(SleepTimerTick.Expired, timer.onTimer(scheduled.generation, deadline))
     }
 


### PR DESCRIPTION
## Summary
- replace sleep-timer preset cycling with a dedicated wheel-driven selection screen
- offer Off, end of track, end of album, end of queue, and every exact minute from 1 through 60
- reopen the selector on the active choice and retain the live countdown
- add navigation, scheduling, expiry, replacement, bounds, presentation, catalogue, and icon regression coverage

## Verification
- 923 unit tests passed
- `ANDROID_SDK_ROOT=/opt/android-sdk bash ./gradlew -PallowStaleNative=true testDebugUnitTest lintDebug assembleDebug`
- Kotlin-only change; the isolated worktree lacks the generated native audio binary, so verification used the repository's explicit stale-native allowance

Fixes #72