### PR TITLE
Make list wrapping consistent across all screens

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/ListNavigationPolicy.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/ListNavigationPolicy.kt
@@ -18,7 +18,7 @@ internal object ListNavigationPolicy {
         val last = itemCount - 1
         val current = currentIndex.coerceIn(first, last)
         if (current == last && first == last) return current
-        if (!wraps(screen, wrapLists)) return (current + delta).coerceIn(first, last)
+        if (!wrapLists) return (current + delta).coerceIn(first, last)
 
         val selectableCount = last - first + 1
         val relative = ((current - first + delta) % selectableCount + selectableCount) % selectableCount
@@ -35,10 +35,4 @@ internal object ListNavigationPolicy {
             is Screen.FacetTracks, is Screen.AudiobookChapters, is Screen.AddToPlaylist -> true
             else -> false
         }
-
-    private fun wraps(screen: Screen, preference: Boolean): Boolean = when {
-        screen is Screen.ConfirmAction -> false
-        screen == Screen.EqualizerBands || screen.isRadialMenu() -> true
-        else -> preference
-    }
 }

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerTest.kt
@@ -56,11 +56,16 @@ class AppReducerTest {
         assertEquals(rowCount - 1, AppReducer.reduce(state, AppAction.WheelMoved(5)).state.selectedIndex)
     }
 
-    @Test fun confirmationsRemainBoundedEvenWhenOrdinaryListsWrap() {
+    @Test fun confirmationChoicesFollowTheWrapListsPreference() {
         val state = AppState(screenStack = listOf(ScreenEntry(Screen.ConfirmAction("reset_library"), 1)))
-        assertEquals(1, AppReducer.reduce(state, AppAction.WheelMoved(-1)).state.selectedIndex)
+        assertEquals(2, AppReducer.reduce(state, AppAction.WheelMoved(-1)).state.selectedIndex)
         val onConfirm = state.copy(screenStack = listOf(ScreenEntry(state.currentScreen, 2)))
-        assertEquals(2, AppReducer.reduce(onConfirm, AppAction.WheelMoved(1)).state.selectedIndex)
+        assertEquals(1, AppReducer.reduce(onConfirm, AppAction.WheelMoved(1)).state.selectedIndex)
+
+        val bounded = state.copy(preferences = state.preferences.copy(wrapLists = false))
+        assertEquals(1, AppReducer.reduce(bounded, AppAction.WheelMoved(-1)).state.selectedIndex)
+        val boundedOnConfirm = bounded.copy(screenStack = listOf(ScreenEntry(bounded.currentScreen, 2)))
+        assertEquals(2, AppReducer.reduce(boundedOnConfirm, AppAction.WheelMoved(1)).state.selectedIndex)
     }
 
     @Test fun everyMainMenuItemRemainsReachableWithThePhysicalWheel() {

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/ListNavigationPolicyTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/ListNavigationPolicyTest.kt
@@ -22,18 +22,29 @@ class ListNavigationPolicyTest {
         assertEquals(0, ListNavigationPolicy.nextIndex(Screen.Songs, 0, 5, 1, wrapLists = true))
     }
 
-    @Test fun confirmationPromptIsNeverSelectableAndChoicesNeverWrap() {
+    @Test fun confirmationPromptIsNeverSelectableAndChoicesFollowWrapPreference() {
         val screen = Screen.ConfirmAction("reset_library")
         assertEquals(1, ListNavigationPolicy.firstSelectableIndex(screen, 3))
-        assertEquals(1, ListNavigationPolicy.nextIndex(screen, 1, -1, 3, wrapLists = true))
-        assertEquals(2, ListNavigationPolicy.nextIndex(screen, 2, 1, 3, wrapLists = true))
+        assertEquals(2, ListNavigationPolicy.nextIndex(screen, 1, -1, 3, wrapLists = true))
+        assertEquals(1, ListNavigationPolicy.nextIndex(screen, 2, 1, 3, wrapLists = true))
+        assertEquals(1, ListNavigationPolicy.nextIndex(screen, 1, -1, 3, wrapLists = false))
+        assertEquals(2, ListNavigationPolicy.nextIndex(screen, 2, 1, 3, wrapLists = false))
     }
 
-    @Test fun intentionalValueSelectorsKeepCycling() {
-        assertEquals(6, ListNavigationPolicy.nextIndex(Screen.NowPlayingOptions, 0, -1, 7, wrapLists = false))
-        assertEquals(0, ListNavigationPolicy.nextIndex(Screen.NowPlayingOptions, 6, 1, 7, wrapLists = false))
-        assertEquals(3, ListNavigationPolicy.nextIndex(Screen.QueueManagement, 0, -1, 4, wrapLists = false))
-        assertEquals(0, ListNavigationPolicy.nextIndex(Screen.QueueOptions(7), 3, 1, 4, wrapLists = false))
+    @Test fun customAndRadialMenusFollowWrapListsPreference() {
+        val screens = listOf(
+            Screen.EqualizerBands,
+            Screen.NowPlayingOptions,
+            Screen.QueueManagement,
+            Screen.QueueOptions(7)
+        )
+
+        screens.forEach { screen ->
+            assertEquals(3, ListNavigationPolicy.nextIndex(screen, 0, -1, 4, wrapLists = true))
+            assertEquals(0, ListNavigationPolicy.nextIndex(screen, 3, 1, 4, wrapLists = true))
+            assertEquals(0, ListNavigationPolicy.nextIndex(screen, 0, -1, 4, wrapLists = false))
+            assertEquals(3, ListNavigationPolicy.nextIndex(screen, 3, 1, 4, wrapLists = false))
+        }
     }
 
     @Test fun affectedSettingMenusFollowWrapListsPreference() {


### PR DESCRIPTION
## Summary
- make the Wrap Lists preference authoritative for every selectable screen
- remove forced wrapping from equalizer bands and radial action menus
- make confirmation choices follow the same preference while keeping prompt text non-selectable
- retain bounded queue-reordering behavior because it edits a target position rather than navigating a menu

## Validation
- 923 debug unit tests passed
- debug lint passed

Follow-up to #67 and https://github.com/SchulzCode/Y2Player/issues/67#issuecomment-5417996089