### PR TITLE
Add whole-device QWERTY search

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppAction.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppAction.kt
@@ -39,6 +39,7 @@ sealed interface AppAction {
     data class SafeModeChanged(val enabled: Boolean) : AppAction
     data class ShowMessage(val message: String?) : AppAction
     data class SelectIndex(val index: Int) : AppAction
+    data class PressSearchKey(val key: String) : AppAction
 }
 
 sealed interface AppEffect {
@@ -166,4 +167,5 @@ val AppAction.code: String get() = when (this) {
     is AppAction.SafeModeChanged -> "safe_mode_changed"
     is AppAction.ShowMessage -> "show_message"
     is AppAction.SelectIndex -> "select_index"
+    is AppAction.PressSearchKey -> "search_key"
 }

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
@@ -4,6 +4,7 @@ import com.schulzcode.y2player.core.model.PlaybackStatus
 import com.schulzcode.y2player.core.model.TrackSortOrder
 import com.schulzcode.y2player.core.model.AlbumSortOrder
 import com.schulzcode.y2player.core.model.LibraryScope
+import com.schulzcode.y2player.core.model.Track
 import com.schulzcode.y2player.core.model.SleepTimerMode
 import com.schulzcode.y2player.core.model.YearSortOrder
 import com.schulzcode.y2player.core.state.AppEffect.*
@@ -14,24 +15,25 @@ import com.schulzcode.y2player.core.state.ScreenRow.TrackRow
 import com.schulzcode.y2player.playback.AudioBalance
 
 object AppReducer {
+    private const val MAX_SEARCH_QUERY_LENGTH = 64
     fun reduce(state: AppState, action: AppAction): Reduction = when (action) {
-        is AppAction.WheelMoved -> moveSelection(clearAlphabetScrub(state), action.delta)
+        is AppAction.WheelMoved -> if (state.currentScreen is Screen.Search) moveSearch(state, action.delta) else moveSelection(clearAlphabetScrub(state), action.delta)
         is AppAction.AlphabetMoved -> moveAlphabet(state, action.direction)
         AppAction.EndAlphabetScrub -> Reduction(clearAlphabetScrub(state))
-        AppAction.Confirm -> confirm(clearAlphabetScrub(state))
-        AppAction.ConfirmLong -> confirmLong(clearAlphabetScrub(state))
+        AppAction.Confirm -> if (state.currentScreen is Screen.Search) confirmSearch(state) else confirm(clearAlphabetScrub(state))
+        AppAction.ConfirmLong -> if (state.currentScreen is Screen.Search) confirmSearchLong(state) else confirmLong(clearAlphabetScrub(state))
         AppAction.ShowNowPlaying -> showNowPlaying(clearAlphabetScrub(state))
         AppAction.Back -> if (state.transientMessage != null) {
             Reduction(clearAlphabetScrub(state).copy(transientMessage = null))
         } else {
-            back(clearAlphabetScrub(state))
+            if (state.currentScreen is Screen.Search) backSearch(clearAlphabetScrub(state)) else back(clearAlphabetScrub(state))
         }
         AppAction.NavigateHome -> Reduction(
             if (state.screenStack.size == 1 && state.currentScreen == Screen.MainMenu) clearAlphabetScrub(state)
             else clearAlphabetScrub(state).copy(screenStack = listOf(ScreenEntry(Screen.MainMenu)))
         )
-        AppAction.Left -> Reduction(state, listOf(PreviousTrack))
-        AppAction.Right -> Reduction(state, listOf(NextTrack))
+        AppAction.Left -> if (state.currentScreen is Screen.Search) moveSearchHorizontal(state, -1) else Reduction(state, listOf(PreviousTrack))
+        AppAction.Right -> if (state.currentScreen is Screen.Search) moveSearchHorizontal(state, 1) else Reduction(state, listOf(NextTrack))
         AppAction.PlayPause -> Reduction(state, listOf(TogglePlayback))
         AppAction.MediaNext -> Reduction(state, listOf(NextTrack))
         AppAction.MediaPrevious -> Reduction(state, listOf(PreviousTrack))
@@ -57,7 +59,8 @@ object AppReducer {
         )
         is AppAction.SafeModeChanged -> Reduction(state.copy(safeMode = action.enabled))
         is AppAction.ShowMessage -> Reduction(state.copy(transientMessage = action.message))
-        is AppAction.SelectIndex -> Reduction(normalizeSelection(setSelected(clearAlphabetScrub(state), action.index.coerceAtLeast(0))))
+        is AppAction.SelectIndex -> if (state.currentScreen is Screen.Search) focusSearchResult(state, action.index) else Reduction(normalizeSelection(setSelected(clearAlphabetScrub(state), action.index.coerceAtLeast(0))))
+        is AppAction.PressSearchKey -> pressSearchKey(state, action.key)
     }
 
     private fun moveAlphabet(state: AppState, direction: Int): Reduction {
@@ -101,6 +104,108 @@ object AppReducer {
         return if (next == state.selectedIndex) Reduction(state) else Reduction(setSelected(state, next))
     }
 
+    private fun moveSearch(state: AppState, delta: Int): Reduction {
+        val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
+        if (!screen.resultsFocused) {
+            return Reduction(replaceSearch(state, SearchKeyboard.moveVertical(screen, delta.sign())))
+        }
+        val count = ScreenContent.rows(state).size
+        if (count == 0) return Reduction(replaceSearch(state, screen.copy(resultsFocused = false)))
+        val next = ListNavigationPolicy.nextIndex(screen, state.selectedIndex, delta, count, state.preferences.wrapLists)
+        return Reduction(setSelected(state, next))
+    }
+
+    private fun moveSearchHorizontal(state: AppState, delta: Int): Reduction {
+        val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
+        return if (screen.resultsFocused) {
+            if (delta < 0) Reduction(replaceSearch(state, screen.copy(resultsFocused = false))) else Reduction(state)
+        } else Reduction(replaceSearch(state, SearchKeyboard.moveHorizontal(screen, delta)))
+    }
+
+    private fun pressSearchKey(state: AppState, key: String): Reduction {
+        val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
+        if (key !in SearchKeyboard.rows.flatten()) return Reduction(state)
+        return applySearchKey(state, screen, key)
+    }
+
+    private fun confirmSearch(state: AppState): Reduction {
+        val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
+        if (!screen.resultsFocused) return applySearchKey(state, screen, SearchKeyboard.key(screen))
+        val result = ScreenContent.searchResults(state).getOrNull(state.selectedIndex) ?: return Reduction(state)
+        return when (result) {
+            is DeviceSearchResult.TrackResult -> Reduction(toNowPlaying(state), listOf(PlayCollection(listOf(result.track.id), 0)))
+            is DeviceSearchResult.AlbumResult -> push(state, Screen.AlbumSongs(result.key.title, result.key.albumArtist))
+            is DeviceSearchResult.ArtistResult -> push(state, Screen.ArtistAlbums(result.title))
+            is DeviceSearchResult.PlaylistResult -> push(state, Screen.PlaylistTracks(result.id, result.title))
+            is DeviceSearchResult.AudiobookResult -> push(state, Screen.AudiobookOptions(result.folderKey))
+        }
+    }
+
+    private fun confirmSearchLong(state: AppState): Reduction {
+        val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
+        if (!screen.resultsFocused) return confirmSearch(state)
+        val result = ScreenContent.searchResults(state).getOrNull(state.selectedIndex) ?: return Reduction(state)
+        return when (result) {
+            is DeviceSearchResult.TrackResult -> push(state, Screen.TrackOptions(result.track.id))
+            is DeviceSearchResult.AlbumResult -> {
+                val ids = state.library.index.organization.albumTracks(LibraryScope.All, result.key).map(Track::id)
+                push(state, Screen.CollectionOptions(result.title, ids))
+            }
+            is DeviceSearchResult.ArtistResult -> {
+                val ids = state.library.index.organization.artistTracks(
+                    LibraryScope.All, result.title, state.preferences.albumSortOrder
+                ).map(Track::id)
+                push(state, Screen.CollectionOptions(result.title, ids))
+            }
+            is DeviceSearchResult.PlaylistResult -> push(
+                state,
+                Screen.CollectionOptions(result.title, state.library.playlistTrackIds[result.id].orEmpty())
+            )
+            is DeviceSearchResult.AudiobookResult -> push(state, Screen.AudiobookOptions(result.folderKey))
+        }
+    }
+
+    private fun applySearchKey(state: AppState, screen: Screen.Search, key: String): Reduction = when (key) {
+        SearchKeyboard.RESULTS -> if (ScreenContent.rows(state).isEmpty()) Reduction(state)
+            else Reduction(replaceSearch(state, screen.copy(resultsFocused = true)))
+        SearchKeyboard.DELETE -> updateSearchQuery(state, screen.query.dropLast(1))
+        SearchKeyboard.CLEAR -> updateSearchQuery(state, "")
+        SearchKeyboard.SPACE -> if (screen.query.isBlank() || screen.query.endsWith(' ')) Reduction(state)
+            else updateSearchQuery(state, screen.query + " ")
+        else -> if (screen.query.length >= MAX_SEARCH_QUERY_LENGTH) Reduction(state)
+            else updateSearchQuery(state, screen.query + key)
+    }
+
+    private fun updateSearchQuery(state: AppState, query: String): Reduction {
+        val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
+        return Reduction(replaceSearch(state, screen.copy(query = query, resultsFocused = false), selectedIndex = 0))
+    }
+
+    private fun focusSearchResult(state: AppState, index: Int): Reduction {
+        val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
+        val last = ScreenContent.rows(state).lastIndex
+        if (last < 0) return Reduction(state)
+        return Reduction(replaceSearch(state, screen.copy(resultsFocused = true), index.coerceIn(0, last)))
+    }
+
+    private fun backSearch(state: AppState): Reduction {
+        val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
+        return when {
+            screen.resultsFocused -> Reduction(replaceSearch(state, screen.copy(resultsFocused = false)))
+            screen.query.isNotEmpty() -> updateSearchQuery(state, screen.query.dropLast(1))
+            else -> back(state)
+        }
+    }
+
+    private fun replaceSearch(state: AppState, screen: Screen.Search, selectedIndex: Int = state.selectedIndex): AppState =
+        state.copy(screenStack = state.screenStack.dropLast(1) + ScreenEntry(screen, selectedIndex))
+
+    private fun Int.sign(): Int = when {
+        this < 0 -> -1
+        this > 0 -> 1
+        else -> 0
+    }
+
     private fun confirm(state: AppState): Reduction {
         if (state.currentScreen == Screen.NowPlaying) return Reduction(state)
         val screenRows = ScreenContent.rows(state)
@@ -108,6 +213,7 @@ object AppReducer {
         val row = screenRows.getOrNull(state.selectedIndex) ?: return Reduction(state)
         return when (val screen = state.currentScreen) {
             Screen.MainMenu -> confirmMainMenu(state, row)
+            is Screen.Search -> confirmSearch(state)
             Screen.Music -> confirmMusic(state, row)
             Screen.Audiobooks -> confirmAudiobook(state, row)
             is Screen.AudiobookOptions -> confirmAudiobookOptions(state, screen, row)
@@ -193,6 +299,7 @@ object AppReducer {
         return when (key) {
             "music" -> push(state, Screen.Music)
             "audiobooks" -> Reduction(pushState(state, Screen.Audiobooks), listOf(RefreshAudiobooks))
+            "search" -> push(state, Screen.Search())
             "shuffle_all" -> Reduction(toNowPlaying(state), listOf(ShuffleAll))
             "settings" -> push(state, Screen.Settings)
             else -> Reduction(state)

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/DeviceSearch.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/DeviceSearch.kt
@@ -1,0 +1,100 @@
+package com.schulzcode.y2player.core.state
+
+import com.schulzcode.y2player.core.model.AlbumKey
+import com.schulzcode.y2player.core.model.LibraryScope
+import com.schulzcode.y2player.core.model.LibraryState
+import com.schulzcode.y2player.core.model.NaturalTextOrder
+import com.schulzcode.y2player.core.model.Track
+import java.text.Normalizer
+import java.util.Locale
+
+internal sealed interface DeviceSearchResult {
+    val title: String
+    val score: Int
+
+    data class TrackResult(val track: Track, override val score: Int) : DeviceSearchResult {
+        override val title: String = track.title
+    }
+    data class AlbumResult(val key: AlbumKey, val artist: String, val artworkTrackId: Long?, override val score: Int) : DeviceSearchResult {
+        override val title: String = key.title
+    }
+    data class ArtistResult(override val title: String, val artworkTrackId: Long?, override val score: Int) : DeviceSearchResult
+    data class PlaylistResult(val id: Long, override val title: String, val trackCount: Int, override val score: Int) : DeviceSearchResult
+    data class AudiobookResult(val folderKey: String, override val title: String, val artworkTrackId: Long?, override val score: Int) : DeviceSearchResult
+}
+
+internal object DeviceSearch {
+    private const val MAX_RESULTS = 100
+    private val DIACRITICS = Regex("\\p{M}+")
+    private val WHITESPACE = Regex("\\s+")
+
+    fun find(library: LibraryState, rawQuery: String): List<DeviceSearchResult> {
+        val query = normalized(rawQuery)
+        if (query.isEmpty()) return emptyList()
+        val tokens = query.split(' ').filter(String::isNotEmpty)
+        val results = ArrayList<DeviceSearchResult>()
+
+        library.availableTracks.forEach { track ->
+            score(tokens, track.title, track.displayArtist, track.displayAlbum, track.fileName, track.genre, track.composer)
+                ?.let { results += DeviceSearchResult.TrackResult(track, it) }
+        }
+        library.index.organization.albums(LibraryScope.All, com.schulzcode.y2player.core.model.AlbumSortOrder.TITLE)
+            .forEach { album ->
+                score(tokens, album.title, album.albumArtist)?.let {
+                    results += DeviceSearchResult.AlbumResult(album.key, album.albumArtist, album.tracks.firstOrNull()?.id, it)
+                }
+            }
+        library.index.organization.artists(LibraryScope.All).forEach { artist ->
+            score(tokens, artist.name)?.let {
+                results += DeviceSearchResult.ArtistResult(artist.name, artist.tracks.firstOrNull()?.id, it)
+            }
+        }
+        library.playlists.forEach { playlist ->
+            score(tokens, playlist.name)?.let {
+                results += DeviceSearchResult.PlaylistResult(playlist.id, playlist.name, playlist.trackCount, it)
+            }
+        }
+        library.availableTracks.asSequence().filter(Track::isAudiobookChapter)
+            .groupBy { it.audiobookFolderKey.orEmpty() }.forEach { (folderKey, tracks) ->
+                val title = tracks.first().relativePath.substringBeforeLast('/', "")
+                    .substringAfterLast('/').ifBlank { tracks.first().displayAlbum }
+                score(tokens, title, tracks.first().displayArtist, tracks.first().displayAlbum)?.let {
+                    results += DeviceSearchResult.AudiobookResult(folderKey, title, tracks.firstOrNull()?.id, it)
+                }
+            }
+
+        return results.sortedWith { first, second ->
+            first.score.compareTo(second.score)
+                .takeIf { it != 0 }
+                ?: typeOrder(first).compareTo(typeOrder(second)).takeIf { it != 0 }
+                ?: NaturalTextOrder.compare(first.title, second.title)
+        }.take(MAX_RESULTS)
+    }
+
+    private fun score(tokens: List<String>, vararg fields: String?): Int? {
+        val values = fields.mapNotNull { it?.takeIf(String::isNotBlank)?.let(::normalized) }
+        if (values.isEmpty() || tokens.any { token -> values.none { token in it } }) return null
+        return tokens.sumOf { token ->
+            values.minOf { value -> when {
+                value == token -> 0
+                value.startsWith(token) -> 1
+                value.split(' ').any { it.startsWith(token) } -> 2
+                else -> 3
+            } }
+        }
+    }
+
+    private fun normalized(value: String): String = Normalizer.normalize(value, Normalizer.Form.NFD)
+        .replace(DIACRITICS, "")
+        .lowercase(Locale.ROOT)
+        .trim()
+        .replace(WHITESPACE, " ")
+
+    private fun typeOrder(result: DeviceSearchResult): Int = when (result) {
+        is DeviceSearchResult.TrackResult -> 0
+        is DeviceSearchResult.AlbumResult -> 1
+        is DeviceSearchResult.ArtistResult -> 2
+        is DeviceSearchResult.PlaylistResult -> 3
+        is DeviceSearchResult.AudiobookResult -> 4
+    }
+}

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/Screen.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/Screen.kt
@@ -5,6 +5,12 @@ import com.schulzcode.y2player.core.model.LibraryScope
 
 sealed interface Screen {
     data object MainMenu : Screen
+    data class Search(
+        val query: String = "",
+        val keyboardRow: Int = 0,
+        val keyboardColumn: Int = 0,
+        val resultsFocused: Boolean = false
+    ) : Screen
     data object Music : Screen
     data object Audiobooks : Screen
     data class AudiobookOptions(val folderKey: String) : Screen
@@ -97,6 +103,7 @@ fun Screen.isRadialMenu(): Boolean =
 // R8 renames these classes, so simpleName logs as `b0` in release builds.
 val Screen.code: String get() = when (this) {
     Screen.MainMenu -> "main_menu"
+    is Screen.Search -> "search"
     Screen.Music -> "music"
     Screen.Audiobooks -> "audiobooks"
     is Screen.AudiobookOptions -> "audiobook_options"

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/ScreenContent.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/ScreenContent.kt
@@ -88,6 +88,7 @@ sealed interface ScreenGroupTarget {
 object ScreenContent {
     fun title(state: AppState): String = when (val screen = state.currentScreen) {
         Screen.MainMenu -> "Y2 Player"
+        is Screen.Search -> "Search"
         Screen.Music -> "Music"
         Screen.Audiobooks -> "Audiobooks"
         is Screen.AudiobookOptions -> audiobookName(state, screen.folderKey) ?: "Book"
@@ -185,6 +186,7 @@ object ScreenContent {
     }
 
     private fun contentRevision(state: AppState): Long = when (state.currentScreen) {
+        is Screen.Search -> state.library.revision
         Screen.RecentlyPlayed, Screen.Playlists, is Screen.PlaylistTracks,
         Screen.Audiobooks -> state.library.revision
         else -> state.library.tracksRevision
@@ -192,6 +194,7 @@ object ScreenContent {
 
     private fun buildRows(state: AppState): List<ScreenRow> = when (val screen = state.currentScreen) {
         Screen.MainMenu -> mainMenuRows(state)
+        is Screen.Search -> searchRows(state)
         Screen.Music -> musicRows(state)
         Screen.Audiobooks -> audiobookRows(state)
         is Screen.AudiobookOptions -> audiobookOptionRows(state, screen.folderKey)
@@ -308,12 +311,42 @@ object ScreenContent {
     private fun mainMenuRows(state: AppState): List<ScreenRow> = buildList {
         add(ScreenRow.Action("Music", "Songs, albums, artists and playlists", "music"))
         add(ScreenRow.Action("Audiobooks", "Pick up where you stopped", "audiobooks"))
+        add(ScreenRow.Action("Search", "Find anything on this device", "search"))
         // Do not offer a destructive Shuffle All shortcut over a live or restored
         // session. Now Playing remains available through the playback panel.
         if (state.playback.currentTrackId == null && state.playback.queue.isEmpty()) {
             add(ScreenRow.Action("Shuffle All", "Every track in random order", "shuffle_all"))
         }
         add(ScreenRow.Action("Settings", if (state.safeMode) "SAFE MODE" else null, "settings"))
+    }
+
+    internal fun searchResults(state: AppState): List<DeviceSearchResult> {
+        val screen = state.currentScreen as? Screen.Search ?: return emptyList()
+        return DeviceSearch.find(state.library, screen.query)
+    }
+
+    private fun searchRows(state: AppState): List<ScreenRow> = searchResults(state).mapIndexed { index, result ->
+        when (result) {
+            is DeviceSearchResult.TrackResult -> ScreenRow.Action(
+                result.title,
+                if (result.track.isAudiobookChapter) "Audiobook chapter · ${result.track.displayArtist}"
+                else "Song · ${result.track.displayArtist}",
+                "search_track:$index",
+                result.track.id
+            )
+            is DeviceSearchResult.AlbumResult -> ScreenRow.Action(
+                result.title, "Album · ${result.artist}", "search_album:$index", result.artworkTrackId
+            )
+            is DeviceSearchResult.ArtistResult -> ScreenRow.Action(
+                result.title, "Artist", "search_artist:$index", result.artworkTrackId
+            )
+            is DeviceSearchResult.PlaylistResult -> ScreenRow.Action(
+                result.title, "Playlist · ${trackCountLabel(result.trackCount)}", "search_playlist:$index"
+            )
+            is DeviceSearchResult.AudiobookResult -> ScreenRow.Action(
+                result.title, "Audiobook", "search_audiobook:$index", result.artworkTrackId
+            )
+        }
     }
 
     fun selectedCollection(state: AppState): Pair<String, List<Long>>? {
@@ -1595,6 +1628,7 @@ object ScreenContent {
     private fun isLargeScreen(screen: Screen): Boolean = when (screen) {
         Screen.Songs, Screen.Favorites, Screen.RecentlyPlayed, Screen.Albums, Screen.Artists,
         Screen.Genres, Screen.Years, Screen.Playlists, Screen.Queue, Screen.Audiobooks -> true
+        is Screen.Search -> true
         is Screen.AlbumSongs, is Screen.ArtistAlbums, is Screen.ArtistSongs,
         is Screen.FacetMenu, is Screen.FacetArtists, is Screen.FacetAlbums,
         is Screen.FacetArtistAlbums, is Screen.FacetTracks,

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/SearchKeyboard.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/SearchKeyboard.kt
@@ -1,0 +1,43 @@
+package com.schulzcode.y2player.core.state
+
+internal object SearchKeyboard {
+    const val SPACE = "space"
+    const val DELETE = "delete"
+    const val CLEAR = "clear"
+    const val RESULTS = "results"
+
+    val rows: List<List<String>> = listOf(
+        "QWERTYUIOP".map(Char::toString),
+        "ASDFGHJKL".map(Char::toString),
+        "ZXCVBNM".map(Char::toString) + DELETE,
+        listOf(SPACE, CLEAR, RESULTS)
+    )
+
+    fun key(screen: Screen.Search): String = rows[screen.keyboardRow][screen.keyboardColumn]
+
+    fun moveHorizontal(screen: Screen.Search, delta: Int): Screen.Search {
+        val row = rows[screen.keyboardRow]
+        val column = ((screen.keyboardColumn + delta) % row.size + row.size) % row.size
+        return screen.copy(keyboardColumn = column)
+    }
+
+    fun moveVertical(screen: Screen.Search, delta: Int): Screen.Search {
+        val nextRow = (screen.keyboardRow + delta).coerceIn(0, rows.lastIndex)
+        if (nextRow == screen.keyboardRow) return screen
+        val oldSize = rows[screen.keyboardRow].size
+        val nextSize = rows[nextRow].size
+        val fraction = if (oldSize <= 1) 0f else screen.keyboardColumn.toFloat() / (oldSize - 1)
+        return screen.copy(
+            keyboardRow = nextRow,
+            keyboardColumn = (fraction * (nextSize - 1)).toInt().coerceIn(0, nextSize - 1)
+        )
+    }
+
+    fun label(key: String): String = when (key) {
+        SPACE -> "SPACE"
+        DELETE -> "⌫"
+        CLEAR -> "CLEAR"
+        RESULTS -> "RESULTS"
+        else -> key
+    }
+}

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2IconPainter.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2IconPainter.kt
@@ -11,7 +11,7 @@ enum class Y2Icon {
     ACTION, REFRESH, HEADPHONES, SPEAKER, DISCONNECTED, UNKNOWN, CHEVRON, PLAY, PAUSE,
     PREVIOUS, NEXT, CHECK, PREPARING, WARNING, SHUFFLE, REPEAT, TIMER, DAC,
     MUSIC, BOOK, LIBRARY, SLIDERS, VOLUME, EQUALIZER, CROSSFADE, HISTORY, REMOVE, SYSTEM, WHEEL,
-    CHAPTERS
+    CHAPTERS, SEARCH
 }
 
 class Y2IconPainter(private val paint: Paint, density: Float) {
@@ -53,6 +53,10 @@ class Y2IconPainter(private val paint: Paint, density: Float) {
             Y2Icon.SYSTEM -> drawSystem(canvas, left, top, size)
             Y2Icon.WHEEL -> drawWheel(canvas, centerX, centerY, size)
             Y2Icon.CHAPTERS -> drawChapters(canvas, left, top, size)
+            Y2Icon.SEARCH -> {
+                canvas.drawCircle(centerX - size * .1f, centerY - size * .1f, size * .27f, paint)
+                canvas.drawLine(centerX + size * .1f, centerY + size * .1f, centerX + size * .35f, centerY + size * .35f, paint)
+            }
             Y2Icon.QUEUE -> drawQueue(canvas, left, top, size)
             Y2Icon.BLUETOOTH -> drawBluetooth(canvas, left, top, size)
             Y2Icon.SETTINGS -> drawSettings(canvas, centerX, centerY, size)

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
@@ -23,6 +23,7 @@ import com.schulzcode.y2player.core.state.AppState
 import com.schulzcode.y2player.core.state.Screen
 import com.schulzcode.y2player.core.state.ScreenContent
 import com.schulzcode.y2player.core.state.ScreenRow
+import com.schulzcode.y2player.core.state.SearchKeyboard
 import com.schulzcode.y2player.core.state.SleepTimerPresentation
 import com.schulzcode.y2player.core.state.isRadialMenu
 import com.schulzcode.y2player.core.state.isProgressOnlyUpdate
@@ -467,7 +468,9 @@ class Y2PlayerView(
             drawNowPlaying(canvas)
         } else {
             if (hasDetailHeader()) drawDetailHeader(canvas)
+            if (state.currentScreen is Screen.Search) drawSearchQuery(canvas)
             drawRows(canvas)
+            if (state.currentScreen is Screen.Search) drawSearchKeyboard(canvas)
         }
         if (isSplitHome()) drawHomePane(canvas)
         drawFooter(canvas)
@@ -492,9 +495,15 @@ class Y2PlayerView(
 
     private fun hasDetailHeader(): Boolean = state.currentScreen is Screen.AlbumSongs || state.currentScreen is Screen.ArtistSongs
 
-    private fun rowAreaTop(): Float = headerHeight + if (hasDetailHeader()) detailHeaderHeight else 0f
+    private fun rowAreaTop(): Float = headerHeight + when {
+        state.currentScreen is Screen.Search -> SEARCH_QUERY_HEIGHT_DP * density
+        hasDetailHeader() -> detailHeaderHeight
+        else -> 0f
+    }
 
-    private fun rowAreaBottom(): Float = height - footerHeight - if (cachedMessageSource != null) 66f * density else 0f
+    private fun rowAreaBottom(): Float = height - footerHeight -
+        if (state.currentScreen is Screen.Search) SEARCH_KEYBOARD_HEIGHT_DP * density else 0f -
+        if (cachedMessageSource != null) 66f * density else 0f
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         return when (event.action) {
@@ -511,6 +520,12 @@ class Y2PlayerView(
             MotionEvent.ACTION_UP -> {
                 if (!pendingTouchActive) true else {
                     pendingTouchActive = false
+                    val searchKey = searchKeyAt(event.x, event.y)
+                    if (searchKey != null) {
+                        pendingTouchIndex = null
+                        dispatch(AppAction.PressSearchKey(searchKey))
+                        return true
+                    }
                     if (state.currentScreen.isRadialMenu()) {
                         pendingTouchIndex = null
                         performClick()
@@ -552,6 +567,71 @@ class Y2PlayerView(
         if (y < rowsTop || y >= rowAreaBottom()) return null
         if (x >= rowAreaRight()) return null
         return (visibleStart + ((y - rowsTop) / rowHeight).toInt()).takeIf { it in rows.indices }
+    }
+
+    private fun searchKeyAt(x: Float, y: Float): String? {
+        if (state.currentScreen !is Screen.Search) return null
+        val top = searchKeyboardTop()
+        if (y < top || y >= height - footerHeight || x !in 0f..width.toFloat()) return null
+        val rowHeight = (height - footerHeight - top) / SearchKeyboard.rows.size
+        val row = ((y - top) / rowHeight).toInt().coerceIn(0, SearchKeyboard.rows.lastIndex)
+        val keys = SearchKeyboard.rows[row]
+        val keyWidth = width.toFloat() / keys.size
+        return keys[(x / keyWidth).toInt().coerceIn(0, keys.lastIndex)]
+    }
+
+    private fun drawSearchQuery(canvas: Canvas) {
+        val screen = state.currentScreen as? Screen.Search ?: return
+        val top = headerHeight
+        val bottom = rowAreaTop()
+        paint.style = Paint.Style.FILL
+        paint.color = palette.surface
+        canvas.drawRect(0f, top, width.toFloat(), bottom, paint)
+        boldPaint.textAlign = Paint.Align.LEFT
+        boldPaint.textSize = Y2UiTheme.BODY_SP * density
+        boldPaint.color = if (screen.query.isEmpty()) palette.secondaryText else palette.primaryText
+        val query = screen.query.ifEmpty { "Type to search this device…" }
+        canvas.drawText(ellipsize(query, width - 86f * density, boldPaint), 12f * density, top + 25f * density, boldPaint)
+        paint.textAlign = Paint.Align.RIGHT
+        paint.textSize = Y2UiTheme.META_SP * density
+        paint.color = palette.secondaryText
+        canvas.drawText(if (screen.query.isEmpty()) "" else rows.size.toString(), width - 12f * density, top + 24f * density, paint)
+        paint.textAlign = Paint.Align.LEFT
+    }
+
+    private fun searchKeyboardTop(): Float = height - footerHeight - SEARCH_KEYBOARD_HEIGHT_DP * density
+
+    private fun drawSearchKeyboard(canvas: Canvas) {
+        val screen = state.currentScreen as? Screen.Search ?: return
+        val top = searchKeyboardTop()
+        val keyboardHeight = height - footerHeight - top
+        val keyHeight = keyboardHeight / SearchKeyboard.rows.size
+        paint.style = Paint.Style.FILL
+        paint.color = palette.surface
+        canvas.drawRect(0f, top, width.toFloat(), height - footerHeight, paint)
+        SearchKeyboard.rows.forEachIndexed { rowIndex, keys ->
+            val keyWidth = width.toFloat() / keys.size
+            keys.forEachIndexed { columnIndex, key ->
+                val left = columnIndex * keyWidth + 2f * density
+                val keyTop = top + rowIndex * keyHeight + 2f * density
+                val right = (columnIndex + 1) * keyWidth - 2f * density
+                val bottom = keyTop + keyHeight - 4f * density
+                val focused = !screen.resultsFocused && rowIndex == screen.keyboardRow && columnIndex == screen.keyboardColumn
+                paint.color = if (focused) palette.accent else palette.background
+                reusableRectF.set(left, keyTop, right, bottom)
+                canvas.drawRoundRect(reusableRectF, 4f * density, 4f * density, paint)
+                boldPaint.textAlign = Paint.Align.CENTER
+                boldPaint.textSize = if (rowIndex == SearchKeyboard.rows.lastIndex) 10f * density else 13f * density
+                boldPaint.color = if (focused) palette.background else palette.primaryText
+                canvas.drawText(
+                    SearchKeyboard.label(key),
+                    (left + right) * .5f,
+                    keyTop + keyHeight * .5f + 4f * density,
+                    boldPaint
+                )
+            }
+        }
+        boldPaint.textAlign = Paint.Align.LEFT
     }
 
     private fun drawHeader(canvas: Canvas) {
@@ -697,7 +777,8 @@ class Y2PlayerView(
             val slot = index - cachedRowStart
             val top = rowsTop + (index - visibleStart) * rowHeight
             val bottom = top + rowHeight
-            val focused = index == state.selectedIndex
+            val focused = index == state.selectedIndex &&
+                ((state.currentScreen as? Screen.Search)?.resultsFocused != false)
             val visual = Y2UiLogic.rowVisualState(focused, cachedActive[slot], cachedUnavailable[slot])
             if (focused) drawFocus(canvas, top, bottom) else if (cachedActive[slot]) drawActiveRow(canvas, top, bottom)
 
@@ -1949,6 +2030,8 @@ class Y2PlayerView(
 
     private fun updateFooterPosition() {
         cachedFooterPosition = when {
+            state.currentScreen is Screen.Search && !(state.currentScreen as Screen.Search).resultsFocused ->
+                if ((state.currentScreen as Screen.Search).query.isEmpty()) "" else "${rows.size} found"
             !isNowPlayingSurface() && rows.isNotEmpty() ->
                 "${state.selectedIndex + 1}/${rows.size}"
             isNowPlayingSurface() && state.playback.queue.isNotEmpty() ->
@@ -1960,6 +2043,11 @@ class Y2PlayerView(
     private fun updateFooterHint() {
         val hint = when {
             isNowPlayingSurface() -> ""
+            state.currentScreen is Screen.Search -> if ((state.currentScreen as Screen.Search).resultsFocused) {
+                "WHEEL RESULTS · CENTER OPEN · BACK KEYBOARD"
+            } else {
+                "WHEEL ↑↓ · L/R MOVE · CENTER TYPE · BACK DELETE"
+            }
             state.currentScreen is Screen.QueueMove -> "WHEEL MOVE · CENTER CONFIRM · BACK CANCEL"
             state.currentScreen == Screen.EqualizerBands -> "WHEEL BAND · CENTER CHOOSE · L/R TRACK"
             state.currentScreen == Screen.Brightness || state.currentScreen == Screen.ScreenTimeout ||
@@ -2286,11 +2374,15 @@ class Y2PlayerView(
         private const val ROW_ARTWORK_SIZE_PX = 64
         private const val RADIAL_OPEN_MS = 160f
         private const val RADIAL_CLOSE_MS = 120f
+        private const val SEARCH_QUERY_HEIGHT_DP = 36f
+        // Four 29 dp key rows leave room for two 58 dp search results on the
+        // physical 480x360 panel instead of reducing discovery to one row.
+        private const val SEARCH_KEYBOARD_HEIGHT_DP = 116f
 
         private const val BATTERY_TEXT_REFERENCE = "100%"
         const val SHARED_ARTWORK_SIZE_PX = 256
         private val NAVIGATION_KEYS = setOf(
-            "music", "audiobooks", "songs", "albums", "artists", "playlists",
+            "music", "audiobooks", "search", "songs", "albums", "artists", "playlists",
             "folders", "favorites", "recent", "audio", "settings", "output", "sort", "bluetooth",
             "sound_effects", "reset", "extra_track_info",
             "display", "controls", "storage", "system", "diagnostics", "android_settings", "about",

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2RowIcons.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2RowIcons.kt
@@ -70,6 +70,7 @@ object Y2RowIcons {
         "facet_albums" -> Y2Icon.ALBUM
         "facet_artist_all_tracks" -> Y2Icon.SONG
         "playlists" -> Y2Icon.PLAYLIST
+        "search" -> Y2Icon.SEARCH
         "folders" -> Y2Icon.FOLDER
         "favorites" -> Y2Icon.FAVORITE
         "recent" -> Y2Icon.RECENT
@@ -161,6 +162,11 @@ object Y2RowIcons {
         key.startsWith("brightness:") || key.startsWith("timeout:") -> Y2Icon.DISPLAY
         key.startsWith("sleep_timer_") -> Y2Icon.TIMER
         key.startsWith("eq_band:") || key.startsWith("eq_preset:") || key.startsWith("eq_level:") -> Y2Icon.EQUALIZER
+        key.startsWith("search_track:") -> Y2Icon.MUSIC
+        key.startsWith("search_album:") -> Y2Icon.ALBUM
+        key.startsWith("search_artist:") -> Y2Icon.ARTIST
+        key.startsWith("search_playlist:") -> Y2Icon.PLAYLIST
+        key.startsWith("search_audiobook:") -> Y2Icon.BOOK
         else -> Y2Icon.ACTION
     }
 }

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerNowPlayingTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/AppReducerNowPlayingTest.kt
@@ -56,10 +56,10 @@ class AppReducerNowPlayingTest {
         assertEquals(Screen.Songs, AppReducer.reduce(result.state, AppAction.Back).state.currentScreen)
     }
 
-    @Test fun mainMenuKeepsOnlyTheFourPrimaryDestinations() {
+    @Test fun mainMenuKeepsOnlyTheFivePrimaryDestinations() {
         val rows = ScreenContent.rows(AppState())
         assertEquals(
-            listOf("music", "audiobooks", "shuffle_all", "settings"),
+            listOf("music", "audiobooks", "search", "shuffle_all", "settings"),
             rows.map { (it as ScreenRow.Action).key }
         )
 

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/DeviceSearchTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/DeviceSearchTest.kt
@@ -1,0 +1,51 @@
+package com.schulzcode.y2player.core.state
+
+import com.schulzcode.y2player.core.model.LibraryState
+import com.schulzcode.y2player.core.model.PlaylistSummary
+import com.schulzcode.y2player.core.model.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceSearchTest {
+    private val song = track(1, "Beyoncé Halo", "Beyoncé", "I Am Sasha Fierce", "Music/Halo.mp3")
+    private val audiobook = track(2, "Chapter One", "Frank Herbert", "Dune", "Audiobooks/Dune/01.mp3")
+    private val library = LibraryState(
+        tracks = listOf(song, audiobook),
+        playlists = listOf(PlaylistSummary(7, "Road Mix", 1)),
+        playlistTrackIds = mapOf(7L to listOf(1L))
+    )
+
+    @Test fun `search covers metadata playlists and audiobook folders`() {
+        assertTrue(DeviceSearch.find(library, "halo").any { it is DeviceSearchResult.TrackResult })
+        assertTrue(DeviceSearch.find(library, "sasha").any { it is DeviceSearchResult.AlbumResult })
+        assertTrue(DeviceSearch.find(library, "beyonce").any { it is DeviceSearchResult.ArtistResult })
+        assertTrue(DeviceSearch.find(library, "road").any { it is DeviceSearchResult.PlaylistResult })
+        assertTrue(DeviceSearch.find(library, "dune").any { it is DeviceSearchResult.AudiobookResult })
+    }
+
+    @Test fun `search is accent insensitive and supports multiple tokens`() {
+        val results = DeviceSearch.find(library, "beyonce halo")
+        assertEquals(listOf(song.id), results.filterIsInstance<DeviceSearchResult.TrackResult>().map { it.track.id })
+    }
+
+    @Test fun `blank queries do not enumerate the library`() {
+        assertTrue(DeviceSearch.find(library, "   ").isEmpty())
+    }
+
+    private fun track(id: Long, title: String, artist: String, album: String, relativePath: String) = Track(
+        id = id,
+        volumeId = "sdcard",
+        absolutePath = "/storage/$relativePath",
+        relativePath = relativePath,
+        title = title,
+        artist = artist,
+        album = album,
+        albumArtist = artist,
+        trackNumber = 1,
+        discNumber = 1,
+        durationMs = 60_000,
+        fileSize = 100,
+        modifiedAt = 1
+    )
+}

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/DiagnosticCodeTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/DiagnosticCodeTest.kt
@@ -61,7 +61,7 @@ class DiagnosticCodeTest {
     @Test
     fun `every screen reachable from the reducer has a code`() {
         val screens = listOf<Screen>(
-            Screen.MainMenu, Screen.Music, Screen.Audiobooks,
+            Screen.MainMenu, Screen.Search(), Screen.Music, Screen.Audiobooks,
             Screen.AudiobookOptions("k"), Screen.AudiobookChapters("k"),
             Screen.Songs, Screen.Favorites, Screen.RecentlyPlayed,
             Screen.Albums, Screen.Artists, Screen.Playlists, Screen.Queue, Screen.NowPlaying,

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/MainMenuHierarchyTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/MainMenuHierarchyTest.kt
@@ -55,18 +55,18 @@ class MainMenuHierarchyTest {
     // ---- main menu -------------------------------------------------------------
 
     @Test fun `the main menu fits the split layout without scrolling`() {
-        // 318 px of row area at 58 dp per row leaves room for five; four keeps a margin.
+        // 318 px of row area at 58 dp per row leaves room for all five destinations.
         assertTrue("main menu must not exceed the split-home row budget", ScreenContent.rows(AppState()).size <= 5)
-        assertEquals(4, ScreenContent.rows(AppState()).size)
+        assertEquals(5, ScreenContent.rows(AppState()).size)
     }
 
     @Test fun `the main menu offers Shuffle All when nothing is loaded`() {
-        assertEquals(listOf("music", "audiobooks", "shuffle_all", "settings"), keys(AppState(library = library)))
+        assertEquals(listOf("music", "audiobooks", "search", "shuffle_all", "settings"), keys(AppState(library = library)))
     }
 
     @Test fun `the main menu removes the duplicate Now Playing row during a session`() {
         val state = AppState(library = library, playback = playing)
-        assertEquals(listOf("music", "audiobooks", "settings"), keys(state))
+        assertEquals(listOf("music", "audiobooks", "search", "settings"), keys(state))
     }
 
     @Test fun `right from the main menu skips to the next track`() {

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/ScreenCatalogue.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/ScreenCatalogue.kt
@@ -14,6 +14,7 @@ object ScreenCatalogue {
     private val samples: Map<KClass<out Screen>, Screen> = buildMap {
         fun put(screen: Screen) = put(screen::class, screen)
         put(Screen.MainMenu)
+        put(Screen.Search("test"))
         put(Screen.Music)
         put(Screen.Audiobooks)
         put(Screen.AudiobookOptions("sdcard|AUDIOBOOKS/Dune"))
@@ -97,6 +98,7 @@ object ScreenCatalogue {
     /** Screens whose content depends on a library, so emptiness is legitimate. */
     val contentScreens: Set<String> = setOf(
         Screen.Songs.code, Screen.Favorites.code, Screen.RecentlyPlayed.code,
+        Screen.Search().code,
         Screen.Albums.code, Screen.Artists.code, Screen.Genres.code, Screen.Years.code, Screen.Audiobooks.code,
         Screen.Queue.code, Screen.AlbumSongs("").code, Screen.ArtistAlbums("").code,
         Screen.ArtistSongs("").code, Screen.Folders().code, Screen.PlaylistTracks(0, "").code,

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/ScreenCatalogueTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/ScreenCatalogueTest.kt
@@ -107,6 +107,10 @@ class ScreenCatalogueTest {
             val nested = AppState(screenStack = listOf(ScreenEntry(Screen.MainMenu), ScreenEntry(screen)))
             val back = AppReducer.reduce(nested, AppAction.Back).state
             assertTrue("${screen.code} left an empty stack", back.screenStack.isNotEmpty())
+            if (screen is Screen.Search && screen.query.isNotEmpty()) {
+                assertTrue("search Back should erase before leaving", back.currentScreen is Screen.Search)
+                return@forEach
+            }
             assertTrue(
                 "${screen.code} did not move up",
                 back.screenStack.size < nested.screenStack.size || back.currentScreen == screen
@@ -116,6 +120,7 @@ class ScreenCatalogueTest {
 
     @Test fun `Left and Right are media controls on every screen`() {
         ScreenCatalogue.all().forEach { screen ->
+            if (screen is Screen.Search) return@forEach
             val state = bare(screen).copy(library = LibraryState())
             val right = AppReducer.reduce(state, AppAction.Right)
             val left = AppReducer.reduce(state, AppAction.Left)

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/SearchFlowTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/SearchFlowTest.kt
@@ -1,0 +1,77 @@
+package com.schulzcode.y2player.core.state
+
+import com.schulzcode.y2player.core.model.LibraryState
+import com.schulzcode.y2player.core.model.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchFlowTest {
+    private val track = Track(
+        id = 1,
+        volumeId = "sdcard",
+        absolutePath = "/storage/Music/Bohemian Rhapsody.mp3",
+        relativePath = "Music/Bohemian Rhapsody.mp3",
+        title = "Bohemian Rhapsody",
+        artist = "Queen",
+        album = "A Night at the Opera",
+        albumArtist = "Queen",
+        trackNumber = 1,
+        discNumber = 1,
+        durationMs = 60_000,
+        fileSize = 100,
+        modifiedAt = 1
+    )
+
+    @Test fun `main menu opens an empty search keyboard`() {
+        val home = AppState(library = LibraryState(tracks = listOf(track)))
+        val index = ScreenContent.rows(home).indexOfFirst { (it as? ScreenRow.Action)?.key == "search" }
+        val result = AppReducer.reduce(
+            home.copy(screenStack = listOf(ScreenEntry(Screen.MainMenu, index))),
+            AppAction.Confirm
+        ).state
+        assertEquals(Screen.Search(), result.currentScreen)
+        assertTrue(ScreenContent.rows(result).isEmpty())
+    }
+
+    @Test fun `keyboard entry results focus and selection form one predictable flow`() {
+        var state = AppState(
+            screenStack = listOf(ScreenEntry(Screen.MainMenu), ScreenEntry(Screen.Search())),
+            library = LibraryState(tracks = listOf(track))
+        )
+        listOf("B", "O", "H").forEach { key -> state = AppReducer.reduce(state, AppAction.PressSearchKey(key)).state }
+        assertEquals("BOH", (state.currentScreen as Screen.Search).query)
+        assertEquals("Bohemian Rhapsody", ScreenContent.rows(state).single().title)
+
+        state = AppReducer.reduce(state, AppAction.PressSearchKey(SearchKeyboard.RESULTS)).state
+        assertTrue((state.currentScreen as Screen.Search).resultsFocused)
+        val opened = AppReducer.reduce(state, AppAction.Confirm)
+        assertEquals(Screen.NowPlaying, opened.state.currentScreen)
+        assertEquals(AppEffect.PlayCollection(listOf(1), 0), opened.effects.single())
+    }
+
+    @Test fun `Back returns from results then erases then exits`() {
+        val base = AppState(screenStack = listOf(
+            ScreenEntry(Screen.MainMenu),
+            ScreenEntry(Screen.Search(query = "Q", resultsFocused = true))
+        ))
+        val keyboard = AppReducer.reduce(base, AppAction.Back).state
+        assertFalse((keyboard.currentScreen as Screen.Search).resultsFocused)
+        val erased = AppReducer.reduce(keyboard, AppAction.Back).state
+        assertEquals("", (erased.currentScreen as Screen.Search).query)
+        assertEquals(Screen.MainMenu, AppReducer.reduce(erased, AppAction.Back).state.currentScreen)
+    }
+
+    @Test fun `wheel and horizontal buttons navigate the qwerty grid`() {
+        val state = AppState(screenStack = listOf(ScreenEntry(Screen.Search())))
+        val right = AppReducer.reduce(state, AppAction.Right).state.currentScreen as Screen.Search
+        assertEquals("W", SearchKeyboard.key(right))
+        val down = AppReducer.reduce(rightState(state, right), AppAction.WheelMoved(1)).state.currentScreen as Screen.Search
+        assertEquals(1, down.keyboardRow)
+        assertTrue(SearchKeyboard.key(down) in SearchKeyboard.rows[1])
+    }
+
+    private fun rightState(state: AppState, screen: Screen.Search) =
+        state.copy(screenStack = listOf(ScreenEntry(screen)))
+}

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/UiCorrectnessTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/UiCorrectnessTest.kt
@@ -47,14 +47,14 @@ class UiCorrectnessTest {
     @Test fun `a live session has no duplicate Now Playing row`() {
         val state = AppState(library = LibraryState(), playback = playing)
         assertEquals(
-            listOf("music", "audiobooks", "settings"),
+            listOf("music", "audiobooks", "search", "settings"),
             keys(state)
         )
     }
 
     @Test fun `Shuffle All is present only when the session has ended`() {
         val stopped = AppState(library = LibraryState(tracks = listOf(track)), playback = PlaybackSnapshot())
-        assertEquals(listOf("music", "audiobooks", "shuffle_all", "settings"), keys(stopped))
+        assertEquals(listOf("music", "audiobooks", "search", "shuffle_all", "settings"), keys(stopped))
     }
 
     @Test fun `a restored queue has neither Shuffle All nor a duplicate Now Playing row`() {
@@ -63,14 +63,14 @@ class UiCorrectnessTest {
             playback = PlaybackSnapshot(queue = testQueue(1L), currentQueueEntryId = 1L)
         )
         assertEquals(
-            listOf("music", "audiobooks", "settings"),
+            listOf("music", "audiobooks", "search", "settings"),
             keys(restored)
         )
     }
 
     @Test fun `Settings selection survives removal of the idle Shuffle All row`() {
         val idle = AppState(
-            screenStack = listOf(ScreenEntry(Screen.MainMenu, 3)),
+            screenStack = listOf(ScreenEntry(Screen.MainMenu, 4)),
             library = LibraryState(tracks = listOf(track))
         )
         val live = AppReducer.reduce(idle, AppAction.PlaybackChanged(playing)).state
@@ -237,7 +237,7 @@ class UiCorrectnessTest {
     }
 
     private fun allScreens(): List<Screen> = listOf(
-        Screen.MainMenu, Screen.Music, Screen.Audiobooks,
+        Screen.MainMenu, Screen.Search(), Screen.Music, Screen.Audiobooks,
         Screen.AudiobookOptions("sdcard|AUDIOBOOKS/Dune"), Screen.AudiobookChapters("sdcard|AUDIOBOOKS/Dune"),
         Screen.Songs, Screen.Favorites,
         Screen.RecentlyPlayed, Screen.Albums, Screen.AlbumSongs("Album"), Screen.Artists,

--- a/app/src/test/kotlin/com/schulzcode/y2player/ui/Y2UiLogicTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/ui/Y2UiLogicTest.kt
@@ -207,7 +207,7 @@ class Y2UiLogicTest {
     }
 
     @Test fun mainMenuRowCalculationRemainsStableForWheelNavigation() {
-        assertEquals(4, ScreenContent.rows(AppState()).size)
+        assertEquals(5, ScreenContent.rows(AppState()).size)
     }
 
     private fun contrastRatio(first: Int, second: Int): Double {


### PR DESCRIPTION
## UX
- add Search as a first-class main-menu destination
- keep a custom QWERTY keyboard visible at the bottom of the 480x360 display
- support full hardware control: wheel moves vertically, Left/Right horizontally, Center types, Back deletes, and RESULTS focuses matches
- support direct touch on keyboard keys and result rows
- keep two complete result rows visible above the keyboard

## Search
- search tracks and their title, artist, album, filename, genre, and composer metadata
- search albums, artists, playlists, and audiobook folders
- use accent-insensitive multi-token matching with exact and prefix results ranked first
- reuse existing play, browse, playlist, album, artist, audiobook, and long-press context flows
- cap displayed matches at 100 and cache rows by query/library revision

## Validation
- 931 debug unit tests passed
- debug lint and release vital lint passed
- signed release installed and launched on the physical Y2 at 480x360

Fixes #54