### PR TITLE
Improve Search keyboard navigation and space

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
@@ -107,7 +107,10 @@ object AppReducer {
     private fun moveSearch(state: AppState, delta: Int): Reduction {
         val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
         if (!screen.resultsFocused) {
-            return Reduction(replaceSearch(state, SearchKeyboard.moveVertical(screen, delta.sign())))
+            return Reduction(replaceSearch(
+                state,
+                SearchKeyboard.moveLinear(screen, delta, state.preferences.wrapLists)
+            ))
         }
         val count = ScreenContent.rows(state).size
         if (count == 0) return Reduction(replaceSearch(state, screen.copy(resultsFocused = false)))
@@ -199,12 +202,6 @@ object AppReducer {
 
     private fun replaceSearch(state: AppState, screen: Screen.Search, selectedIndex: Int = state.selectedIndex): AppState =
         state.copy(screenStack = state.screenStack.dropLast(1) + ScreenEntry(screen, selectedIndex))
-
-    private fun Int.sign(): Int = when {
-        this < 0 -> -1
-        this > 0 -> 1
-        else -> 0
-    }
 
     private fun confirm(state: AppState): Reduction {
         if (state.currentScreen == Screen.NowPlaying) return Reduction(state)

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/SearchKeyboard.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/SearchKeyboard.kt
@@ -21,16 +21,20 @@ internal object SearchKeyboard {
         return screen.copy(keyboardColumn = column)
     }
 
-    fun moveVertical(screen: Screen.Search, delta: Int): Screen.Search {
-        val nextRow = (screen.keyboardRow + delta).coerceIn(0, rows.lastIndex)
-        if (nextRow == screen.keyboardRow) return screen
-        val oldSize = rows[screen.keyboardRow].size
-        val nextSize = rows[nextRow].size
-        val fraction = if (oldSize <= 1) 0f else screen.keyboardColumn.toFloat() / (oldSize - 1)
-        return screen.copy(
-            keyboardRow = nextRow,
-            keyboardColumn = (fraction * (nextSize - 1)).toInt().coerceIn(0, nextSize - 1)
-        )
+    fun moveLinear(screen: Screen.Search, delta: Int, wrap: Boolean): Screen.Search {
+        val current = rows.take(screen.keyboardRow).sumOf(List<String>::size) + screen.keyboardColumn
+        val total = rows.sumOf(List<String>::size)
+        val next = if (wrap) {
+            ((current + delta) % total + total) % total
+        } else {
+            (current + delta).coerceIn(0, total - 1)
+        }
+        var remaining = next
+        rows.forEachIndexed { rowIndex, row ->
+            if (remaining < row.size) return screen.copy(keyboardRow = rowIndex, keyboardColumn = remaining)
+            remaining -= row.size
+        }
+        return screen
     }
 
     fun label(key: String): String = when (key) {

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
@@ -501,9 +501,9 @@ class Y2PlayerView(
         else -> 0f
     }
 
-    private fun rowAreaBottom(): Float = height - footerHeight -
-        if (state.currentScreen is Screen.Search) SEARCH_KEYBOARD_HEIGHT_DP * density else 0f -
-        if (cachedMessageSource != null) 66f * density else 0f
+    private fun rowAreaBottom(): Float =
+        (if (state.currentScreen is Screen.Search) height.toFloat() - SEARCH_KEYBOARD_HEIGHT_DP * density
+        else height - footerHeight) - if (cachedMessageSource != null) 66f * density else 0f
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         return when (event.action) {
@@ -572,8 +572,8 @@ class Y2PlayerView(
     private fun searchKeyAt(x: Float, y: Float): String? {
         if (state.currentScreen !is Screen.Search) return null
         val top = searchKeyboardTop()
-        if (y < top || y >= height - footerHeight || x !in 0f..width.toFloat()) return null
-        val rowHeight = (height - footerHeight - top) / SearchKeyboard.rows.size
+        if (y < top || y >= height || x !in 0f..width.toFloat()) return null
+        val rowHeight = (height - top) / SearchKeyboard.rows.size
         val row = ((y - top) / rowHeight).toInt().coerceIn(0, SearchKeyboard.rows.lastIndex)
         val keys = SearchKeyboard.rows[row]
         val keyWidth = width.toFloat() / keys.size
@@ -599,16 +599,16 @@ class Y2PlayerView(
         paint.textAlign = Paint.Align.LEFT
     }
 
-    private fun searchKeyboardTop(): Float = height - footerHeight - SEARCH_KEYBOARD_HEIGHT_DP * density
+    private fun searchKeyboardTop(): Float = height - SEARCH_KEYBOARD_HEIGHT_DP * density
 
     private fun drawSearchKeyboard(canvas: Canvas) {
         val screen = state.currentScreen as? Screen.Search ?: return
         val top = searchKeyboardTop()
-        val keyboardHeight = height - footerHeight - top
+        val keyboardHeight = height - top
         val keyHeight = keyboardHeight / SearchKeyboard.rows.size
         paint.style = Paint.Style.FILL
         paint.color = palette.surface
-        canvas.drawRect(0f, top, width.toFloat(), height - footerHeight, paint)
+        canvas.drawRect(0f, top, width.toFloat(), height.toFloat(), paint)
         SearchKeyboard.rows.forEachIndexed { rowIndex, keys ->
             val keyWidth = width.toFloat() / keys.size
             keys.forEachIndexed { columnIndex, key ->
@@ -1652,7 +1652,7 @@ class Y2PlayerView(
     }
 
     private fun drawFooter(canvas: Canvas) {
-        if (isSplitHome()) return
+        if (isSplitHome() || state.currentScreen is Screen.Search) return
 
         if (
             state.playback.currentTrackId != null &&

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/SearchFlowTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/SearchFlowTest.kt
@@ -63,15 +63,29 @@ class SearchFlowTest {
         assertEquals(Screen.MainMenu, AppReducer.reduce(erased, AppAction.Back).state.currentScreen)
     }
 
-    @Test fun `wheel and horizontal buttons navigate the qwerty grid`() {
+    @Test fun `wheel traverses every key while horizontal buttons stay within a row`() {
         val state = AppState(screenStack = listOf(ScreenEntry(Screen.Search())))
         val right = AppReducer.reduce(state, AppAction.Right).state.currentScreen as Screen.Search
         assertEquals("W", SearchKeyboard.key(right))
-        val down = AppReducer.reduce(rightState(state, right), AppAction.WheelMoved(1)).state.currentScreen as Screen.Search
-        assertEquals(1, down.keyboardRow)
-        assertTrue(SearchKeyboard.key(down) in SearchKeyboard.rows[1])
+
+        val wheelOne = AppReducer.reduce(state, AppAction.WheelMoved(1)).state.currentScreen as Screen.Search
+        assertEquals("W", SearchKeyboard.key(wheelOne))
+        val wheelTen = AppReducer.reduce(state, AppAction.WheelMoved(10)).state.currentScreen as Screen.Search
+        assertEquals("A", SearchKeyboard.key(wheelTen))
     }
 
-    private fun rightState(state: AppState, screen: Screen.Search) =
-        state.copy(screenStack = listOf(ScreenEntry(screen)))
+    @Test fun `keyboard wheel follows the global wrapping preference`() {
+        val bounded = AppState(
+            screenStack = listOf(ScreenEntry(Screen.Search())),
+            preferences = PlayerPreferencesState(wrapLists = false)
+        )
+        assertEquals("Q", SearchKeyboard.key(
+            AppReducer.reduce(bounded, AppAction.WheelMoved(-1)).state.currentScreen as Screen.Search
+        ))
+
+        val wrapped = bounded.copy(preferences = bounded.preferences.copy(wrapLists = true))
+        assertEquals(SearchKeyboard.RESULTS, SearchKeyboard.key(
+            AppReducer.reduce(wrapped, AppAction.WheelMoved(-1)).state.currentScreen as Screen.Search
+        ))
+    }
 }


### PR DESCRIPTION
## Summary
- suppress both compact and active-playback footers on Search
- extend the Search keyboard to the physical bottom edge
- make wheel movement traverse every key in QWERTY order instead of staying in one column
- keep Left/Right row-local movement and make wheel boundaries follow Wrap Lists

## Validation
- 933 debug unit tests passed
- debug lint passed

Follow-up to #54