### PR TITLE
fix(search): add dedicated empty state and lock side controls

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/AppReducer.kt
@@ -22,7 +22,7 @@ object AppReducer {
         AppAction.EndAlphabetScrub -> Reduction(clearAlphabetScrub(state))
         AppAction.Confirm -> if (state.currentScreen is Screen.Search) confirmSearch(state) else confirm(clearAlphabetScrub(state))
         AppAction.ConfirmLong -> if (state.currentScreen is Screen.Search) confirmSearchLong(state) else confirmLong(clearAlphabetScrub(state))
-        AppAction.ShowNowPlaying -> showNowPlaying(clearAlphabetScrub(state))
+        AppAction.ShowNowPlaying -> if (state.currentScreen is Screen.Search) Reduction(state) else showNowPlaying(clearAlphabetScrub(state))
         AppAction.Back -> if (state.transientMessage != null) {
             Reduction(clearAlphabetScrub(state).copy(transientMessage = null))
         } else {
@@ -32,16 +32,16 @@ object AppReducer {
             if (state.screenStack.size == 1 && state.currentScreen == Screen.MainMenu) clearAlphabetScrub(state)
             else clearAlphabetScrub(state).copy(screenStack = listOf(ScreenEntry(Screen.MainMenu)))
         )
-        AppAction.Left -> if (state.currentScreen is Screen.Search) moveSearchHorizontal(state, -1) else Reduction(state, listOf(PreviousTrack))
-        AppAction.Right -> if (state.currentScreen is Screen.Search) moveSearchHorizontal(state, 1) else Reduction(state, listOf(NextTrack))
-        AppAction.PlayPause -> Reduction(state, listOf(TogglePlayback))
+        AppAction.Left -> if (state.currentScreen is Screen.Search) Reduction(state) else Reduction(state, listOf(PreviousTrack))
+        AppAction.Right -> if (state.currentScreen is Screen.Search) Reduction(state) else Reduction(state, listOf(NextTrack))
+        AppAction.PlayPause -> if (state.currentScreen is Screen.Search) Reduction(state) else Reduction(state, listOf(TogglePlayback))
         AppAction.MediaNext -> Reduction(state, listOf(NextTrack))
         AppAction.MediaPrevious -> Reduction(state, listOf(PreviousTrack))
         AppAction.MediaStop -> if (state.playback.status == com.schulzcode.y2player.core.model.PlaybackStatus.PLAYING || state.playback.status == com.schulzcode.y2player.core.model.PlaybackStatus.PREPARING) Reduction(state, listOf(TogglePlayback)) else Reduction(state)
-        AppAction.SeekBackward -> Reduction(state, listOf(SeekBy(-state.preferences.seekStepMs.toLong())))
-        AppAction.SeekForward -> Reduction(state, listOf(SeekBy(state.preferences.seekStepMs.toLong())))
-        AppAction.SeekBackwardLong -> Reduction(state, listOf(SeekBy(-state.preferences.longSeekStepMs.toLong())))
-        AppAction.SeekForwardLong -> Reduction(state, listOf(SeekBy(state.preferences.longSeekStepMs.toLong())))
+        AppAction.SeekBackward -> if (state.currentScreen is Screen.Search) Reduction(state) else Reduction(state, listOf(SeekBy(-state.preferences.seekStepMs.toLong())))
+        AppAction.SeekForward -> if (state.currentScreen is Screen.Search) Reduction(state) else Reduction(state, listOf(SeekBy(state.preferences.seekStepMs.toLong())))
+        AppAction.SeekBackwardLong -> if (state.currentScreen is Screen.Search) Reduction(state) else Reduction(state, listOf(SeekBy(-state.preferences.longSeekStepMs.toLong())))
+        AppAction.SeekForwardLong -> if (state.currentScreen is Screen.Search) Reduction(state) else Reduction(state, listOf(SeekBy(state.preferences.longSeekStepMs.toLong())))
         is AppAction.LibraryChanged -> Reduction(preserveSelection(state, state.copy(library = action.library, alphabetScrub = null)))
         is AppAction.PlaybackChanged -> Reduction(playbackChanged(state, action.playback))
         is AppAction.DeviceChanged -> Reduction(preserveSelection(state, state.copy(device = action.device)))
@@ -116,13 +116,6 @@ object AppReducer {
         if (count == 0) return Reduction(replaceSearch(state, screen.copy(resultsFocused = false)))
         val next = ListNavigationPolicy.nextIndex(screen, state.selectedIndex, delta, count, state.preferences.wrapLists)
         return Reduction(setSelected(state, next))
-    }
-
-    private fun moveSearchHorizontal(state: AppState, delta: Int): Reduction {
-        val screen = state.currentScreen as? Screen.Search ?: return Reduction(state)
-        return if (screen.resultsFocused) {
-            if (delta < 0) Reduction(replaceSearch(state, screen.copy(resultsFocused = false))) else Reduction(state)
-        } else Reduction(replaceSearch(state, SearchKeyboard.moveHorizontal(screen, delta)))
     }
 
     private fun pressSearchKey(state: AppState, key: String): Reduction {

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/SearchKeyboard.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/SearchKeyboard.kt
@@ -15,12 +15,6 @@ internal object SearchKeyboard {
 
     fun key(screen: Screen.Search): String = rows[screen.keyboardRow][screen.keyboardColumn]
 
-    fun moveHorizontal(screen: Screen.Search, delta: Int): Screen.Search {
-        val row = rows[screen.keyboardRow]
-        val column = ((screen.keyboardColumn + delta) % row.size + row.size) % row.size
-        return screen.copy(keyboardColumn = column)
-    }
-
     fun moveLinear(screen: Screen.Search, delta: Int, wrap: Boolean): Screen.Search {
         val current = rows.take(screen.keyboardRow).sumOf(List<String>::size) + screen.keyboardColumn
         val total = rows.sumOf(List<String>::size)

--- a/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/ui/Y2PlayerView.kt
@@ -1021,6 +1021,7 @@ class Y2PlayerView(
     }
 
     private fun drawEmptyState(canvas: Canvas) {
+        val search = state.currentScreen as? Screen.Search
         val storageAvailable = state.device.internalStorageAvailable || state.device.removableStorageAvailable
         val kind = Y2UiLogic.emptyState(
             scanning = state.library.isScanning,
@@ -1038,7 +1039,11 @@ class Y2PlayerView(
         val title: String
         val detail: String
         val icon: Y2Icon
-        when (kind) {
+        if (search != null) {
+            title = if (search.query.isBlank()) "Search your device" else "No search results"
+            detail = if (search.query.isBlank()) "Use the keyboard below to begin" else "Try another word or spelling"
+            icon = Y2Icon.SEARCH
+        } else when (kind) {
             EmptyStateKind.SCANNING -> {
                 title = "Scanning music"
                 detail = "Building your library safely"
@@ -1101,7 +1106,7 @@ class Y2PlayerView(
         paint.textSize = Y2UiTheme.BODY_SP * density
         paint.color = palette.secondaryText
         canvas.drawText(ellipsize(detail, width - 34f * density, paint), centerX, centerY + 32f * density, paint)
-        val emptyAction = Y2UiLogic.emptyStateAction(kind)
+        val emptyAction = if (search != null) EmptyStateAction.NONE else Y2UiLogic.emptyStateAction(kind)
         if (emptyAction != EmptyStateAction.NONE) {
             val action = when (emptyAction) {
                 EmptyStateAction.OPEN_STORAGE -> "CENTER · OPEN STORAGE"
@@ -2046,7 +2051,7 @@ class Y2PlayerView(
             state.currentScreen is Screen.Search -> if ((state.currentScreen as Screen.Search).resultsFocused) {
                 "WHEEL RESULTS · CENTER OPEN · BACK KEYBOARD"
             } else {
-                "WHEEL ↑↓ · L/R MOVE · CENTER TYPE · BACK DELETE"
+                "WHEEL KEYS · CENTER TYPE · TOP DELETE"
             }
             state.currentScreen is Screen.QueueMove -> "WHEEL MOVE · CENTER CONFIRM · BACK CANCEL"
             state.currentScreen == Screen.EqualizerBands -> "WHEEL BAND · CENTER CHOOSE · L/R TRACK"

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/SearchFlowTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/SearchFlowTest.kt
@@ -63,15 +63,36 @@ class SearchFlowTest {
         assertEquals(Screen.MainMenu, AppReducer.reduce(erased, AppAction.Back).state.currentScreen)
     }
 
-    @Test fun `wheel traverses every key while horizontal buttons stay within a row`() {
+    @Test fun `wheel traverses every key while side buttons do nothing`() {
         val state = AppState(screenStack = listOf(ScreenEntry(Screen.Search())))
-        val right = AppReducer.reduce(state, AppAction.Right).state.currentScreen as Screen.Search
-        assertEquals("W", SearchKeyboard.key(right))
+        assertEquals(state, AppReducer.reduce(state, AppAction.Left).state)
+        assertEquals(state, AppReducer.reduce(state, AppAction.Right).state)
 
         val wheelOne = AppReducer.reduce(state, AppAction.WheelMoved(1)).state.currentScreen as Screen.Search
         assertEquals("W", SearchKeyboard.key(wheelOne))
         val wheelTen = AppReducer.reduce(state, AppAction.WheelMoved(10)).state.currentScreen as Screen.Search
         assertEquals("A", SearchKeyboard.key(wheelTen))
+    }
+
+    @Test fun `side and bottom button presses and holds do nothing in search`() {
+        val state = AppState(screenStack = listOf(
+            ScreenEntry(Screen.MainMenu),
+            ScreenEntry(Screen.Search(query = "QUEEN"))
+        ))
+        listOf(
+            AppAction.Left,
+            AppAction.Right,
+            AppAction.SeekBackward,
+            AppAction.SeekForward,
+            AppAction.SeekBackwardLong,
+            AppAction.SeekForwardLong,
+            AppAction.PlayPause,
+            AppAction.ShowNowPlaying
+        ).forEach { action ->
+            val reduction = AppReducer.reduce(state, action)
+            assertEquals(action.toString(), state, reduction.state)
+            assertTrue(action.toString(), reduction.effects.isEmpty())
+        }
     }
 
     @Test fun `keyboard wheel follows the global wrapping preference`() {


### PR DESCRIPTION
## Summary
- show Search-specific guidance before typing and a dedicated no-results message after an unmatched query
- ignore left/right and bottom button presses and holds while Search is open
- keep wheel navigation, center input, and top/Back deletion intact
- update the on-screen control hint and regression coverage

## Verification
- Gradle testDebugUnitTest and lintDebug passed

Follow-up to #54.