### PR TITLE
perf(search): index metadata and cache queries

### DIFF
--- a/app/src/main/kotlin/com/schulzcode/y2player/core/state/DeviceSearch.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/state/DeviceSearch.kt
@@ -1,12 +1,15 @@
 package com.schulzcode.y2player.core.state
 
 import com.schulzcode.y2player.core.model.AlbumKey
+import com.schulzcode.y2player.core.model.AlbumSortOrder
 import com.schulzcode.y2player.core.model.LibraryScope
 import com.schulzcode.y2player.core.model.LibraryState
 import com.schulzcode.y2player.core.model.NaturalTextOrder
 import com.schulzcode.y2player.core.model.Track
 import java.text.Normalizer
+import java.util.LinkedHashMap
 import java.util.Locale
+import java.util.PriorityQueue
 
 internal sealed interface DeviceSearchResult {
     val title: String
@@ -23,65 +26,151 @@ internal sealed interface DeviceSearchResult {
     data class AudiobookResult(val folderKey: String, override val title: String, val artworkTrackId: Long?, override val score: Int) : DeviceSearchResult
 }
 
+/** Normalizes and groups metadata once per library, then caches recent query results. */
 internal object DeviceSearch {
     private const val MAX_RESULTS = 100
+    private const val QUERY_CACHE_SIZE = 32
     private val DIACRITICS = Regex("\\p{M}+")
     private val WHITESPACE = Regex("\\s+")
 
+    private val resultOrder = Comparator<DeviceSearchResult> { first, second ->
+        first.score.compareTo(second.score)
+            .takeIf { it != 0 }
+            ?: typeOrder(first).compareTo(typeOrder(second)).takeIf { it != 0 }
+            ?: NaturalTextOrder.compare(first.title, second.title)
+    }
+    private val rankedOrder = Comparator<RankedResult> { first, second ->
+        resultOrder.compare(first.result, second.result).takeIf { it != 0 }
+            ?: first.ordinal.compareTo(second.ordinal)
+    }
+    private val worstFirstOrder = Comparator<RankedResult> { first, second ->
+        rankedOrder.compare(second, first)
+    }
+
+    private var activeIndex: SearchIndex? = null
+    private var indexBuildCount = 0
+
+    @Synchronized
     fun find(library: LibraryState, rawQuery: String): List<DeviceSearchResult> {
         val query = normalized(rawQuery)
         if (query.isEmpty()) return emptyList()
-        val tokens = query.split(' ').filter(String::isNotEmpty)
-        val results = ArrayList<DeviceSearchResult>()
-
-        library.availableTracks.forEach { track ->
-            score(tokens, track.title, track.displayArtist, track.displayAlbum, track.fileName, track.genre, track.composer)
-                ?.let { results += DeviceSearchResult.TrackResult(track, it) }
+        val index = activeIndex?.takeIf { it.matches(library) } ?: SearchIndex(library).also {
+            activeIndex = it
+            indexBuildCount++
         }
-        library.index.organization.albums(LibraryScope.All, com.schulzcode.y2player.core.model.AlbumSortOrder.TITLE)
-            .forEach { album ->
-                score(tokens, album.title, album.albumArtist)?.let {
-                    results += DeviceSearchResult.AlbumResult(album.key, album.albumArtist, album.tracks.firstOrNull()?.id, it)
-                }
-            }
-        library.index.organization.artists(LibraryScope.All).forEach { artist ->
-            score(tokens, artist.name)?.let {
-                results += DeviceSearchResult.ArtistResult(artist.name, artist.tracks.firstOrNull()?.id, it)
-            }
-        }
-        library.playlists.forEach { playlist ->
-            score(tokens, playlist.name)?.let {
-                results += DeviceSearchResult.PlaylistResult(playlist.id, playlist.name, playlist.trackCount, it)
-            }
-        }
-        library.availableTracks.asSequence().filter(Track::isAudiobookChapter)
-            .groupBy { it.audiobookFolderKey.orEmpty() }.forEach { (folderKey, tracks) ->
-                val title = tracks.first().relativePath.substringBeforeLast('/', "")
-                    .substringAfterLast('/').ifBlank { tracks.first().displayAlbum }
-                score(tokens, title, tracks.first().displayArtist, tracks.first().displayAlbum)?.let {
-                    results += DeviceSearchResult.AudiobookResult(folderKey, title, tracks.firstOrNull()?.id, it)
-                }
-            }
-
-        return results.sortedWith { first, second ->
-            first.score.compareTo(second.score)
-                .takeIf { it != 0 }
-                ?: typeOrder(first).compareTo(typeOrder(second)).takeIf { it != 0 }
-                ?: NaturalTextOrder.compare(first.title, second.title)
-        }.take(MAX_RESULTS)
+        return index.results(query)
     }
 
-    private fun score(tokens: List<String>, vararg fields: String?): Int? {
-        val values = fields.mapNotNull { it?.takeIf(String::isNotBlank)?.let(::normalized) }
-        if (values.isEmpty() || tokens.any { token -> values.none { token in it } }) return null
-        return tokens.sumOf { token ->
-            values.minOf { value -> when {
-                value == token -> 0
-                value.startsWith(token) -> 1
-                value.split(' ').any { it.startsWith(token) } -> 2
-                else -> 3
-            } }
+    internal fun clearCacheForTests() {
+        activeIndex = null
+        indexBuildCount = 0
+    }
+
+    internal fun indexBuildCountForTests(): Int = indexBuildCount
+
+    private class SearchIndex(library: LibraryState) {
+        private val libraryIndex = library.index
+        private val playlists = library.playlists
+        private val entries = buildEntries(library)
+        private val queryCache = object : LinkedHashMap<String, List<DeviceSearchResult>>(QUERY_CACHE_SIZE, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, List<DeviceSearchResult>>?): Boolean =
+                size > QUERY_CACHE_SIZE
         }
+
+        fun matches(library: LibraryState): Boolean =
+            library.index === libraryIndex && library.playlists === playlists
+
+        fun results(query: String): List<DeviceSearchResult> = queryCache[query] ?: search(query).also {
+            queryCache[query] = it
+        }
+
+        private fun search(query: String): List<DeviceSearchResult> {
+            val tokens = query.split(' ').filter(String::isNotEmpty)
+            val best = PriorityQueue<RankedResult>(MAX_RESULTS, worstFirstOrder)
+            entries.forEachIndexed { ordinal, entry ->
+                val score = score(tokens, entry.fields) ?: return@forEachIndexed
+                val result = RankedResult(entry.result(score), ordinal)
+                if (best.size < MAX_RESULTS) {
+                    best.add(result)
+                } else if (rankedOrder.compare(result, best.peek()) < 0) {
+                    best.poll()
+                    best.add(result)
+                }
+            }
+            return best.toMutableList().apply { sortWith(rankedOrder) }.map(RankedResult::result)
+        }
+    }
+
+    private data class RankedResult(val result: DeviceSearchResult, val ordinal: Int)
+
+    private class IndexedEntry(
+        val fields: Array<String>,
+        val result: (Int) -> DeviceSearchResult
+    )
+
+    private fun buildEntries(library: LibraryState): List<IndexedEntry> = buildList {
+        library.availableTracks.forEach { track ->
+            add(entry(track.title, track.displayArtist, track.displayAlbum, track.fileName, track.genre, track.composer) {
+                DeviceSearchResult.TrackResult(track, it)
+            })
+        }
+        library.index.organization.albums(LibraryScope.All, AlbumSortOrder.TITLE).forEach { album ->
+            add(entry(album.title, album.albumArtist) {
+                DeviceSearchResult.AlbumResult(album.key, album.albumArtist, album.tracks.firstOrNull()?.id, it)
+            })
+        }
+        library.index.organization.artists(LibraryScope.All).forEach { artist ->
+            add(entry(artist.name) {
+                DeviceSearchResult.ArtistResult(artist.name, artist.tracks.firstOrNull()?.id, it)
+            })
+        }
+        library.playlists.forEach { playlist ->
+            add(entry(playlist.name) {
+                DeviceSearchResult.PlaylistResult(playlist.id, playlist.name, playlist.trackCount, it)
+            })
+        }
+        val audiobookFolders = LinkedHashMap<String, MutableList<Track>>()
+        library.availableTracks.forEach { track ->
+            if (track.isAudiobookChapter) audiobookFolders.getOrPut(track.audiobookFolderKey.orEmpty(), ::ArrayList).add(track)
+        }
+        audiobookFolders.forEach { (folderKey, tracks) ->
+            val first = tracks.first()
+            val title = first.relativePath.substringBeforeLast('/', "")
+                .substringAfterLast('/').ifBlank { first.displayAlbum }
+            add(entry(title, first.displayArtist, first.displayAlbum) {
+                DeviceSearchResult.AudiobookResult(folderKey, title, first.id, it)
+            })
+        }
+    }
+
+    private fun entry(vararg fields: String?, result: (Int) -> DeviceSearchResult): IndexedEntry = IndexedEntry(
+        fields.mapNotNull { it?.takeIf(String::isNotBlank)?.let(::normalized) }.toTypedArray(), result
+    )
+
+    private fun score(tokens: List<String>, fields: Array<String>): Int? {
+        if (fields.isEmpty()) return null
+        var total = 0
+        tokens.forEach { token ->
+            var best = Int.MAX_VALUE
+            fields.forEach { field ->
+                val candidate = fieldScore(field, token)
+                if (candidate < best) best = candidate
+            }
+            if (best == Int.MAX_VALUE) return null
+            total += best
+        }
+        return total
+    }
+
+    private fun fieldScore(field: String, token: String): Int {
+        if (field == token) return 0
+        if (field.startsWith(token)) return 1
+        var match = field.indexOf(token)
+        while (match >= 0) {
+            if (match > 0 && field[match - 1] == ' ') return 2
+            match = field.indexOf(token, match + 1)
+        }
+        return if (token in field) 3 else Int.MAX_VALUE
     }
 
     private fun normalized(value: String): String = Normalizer.normalize(value, Normalizer.Form.NFD)

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/state/DeviceSearchTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/state/DeviceSearchTest.kt
@@ -4,6 +4,7 @@ import com.schulzcode.y2player.core.model.LibraryState
 import com.schulzcode.y2player.core.model.PlaylistSummary
 import com.schulzcode.y2player.core.model.Track
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -31,6 +32,34 @@ class DeviceSearchTest {
 
     @Test fun `blank queries do not enumerate the library`() {
         assertTrue(DeviceSearch.find(library, "   ").isEmpty())
+    }
+
+    @Test fun `index is reused across key presses and query results are cached`() {
+        DeviceSearch.clearCacheForTests()
+        val first = DeviceSearch.find(library, "b")
+        DeviceSearch.find(library, "be")
+        val repeated = DeviceSearch.find(library, "b")
+
+        assertEquals(1, DeviceSearch.indexBuildCountForTests())
+        assertSame(first, repeated)
+    }
+
+    @Test fun `a changed library builds a fresh index`() {
+        DeviceSearch.clearCacheForTests()
+        DeviceSearch.find(library, "halo")
+        val updated = LibraryState(tracks = library.tracks + track(3, "New Song", "Artist", "Album", "Music/New.mp3"))
+        assertTrue(DeviceSearch.find(updated, "new").any { it.title == "New Song" })
+        assertEquals(2, DeviceSearch.indexBuildCountForTests())
+    }
+
+    @Test fun `top one hundred preserves library order for equal matches`() {
+        val duplicates = (1L..150L).map { id ->
+            track(id, "Same title", "Same artist", "Same album", "Music/$id.mp3")
+        }
+        val ids = DeviceSearch.find(LibraryState(tracks = duplicates), "same title")
+            .filterIsInstance<DeviceSearchResult.TrackResult>()
+            .map { it.track.id }
+        assertEquals((1L..100L).toList(), ids)
     }
 
     private fun track(id: Long, title: String, artist: String, album: String, relativePath: String) = Track(


### PR DESCRIPTION
## Summary
- build normalized Search entries once per active library instead of once per key press
- cache the 32 most recent normalized queries so deletion and repeated result access are immediate
- keep only the best 100 candidates in a bounded heap while preserving stable ranking
- retain accent-insensitive, multi-token matching across tracks, albums, artists, playlists, and audiobooks

## Benchmark
Synthetic 10,000-track JVM benchmark after index construction:
- new uncached queries: approximately 2-5 ms
- cached query: approximately 0.02 ms
- initial index construction plus first query: approximately 90 ms

## Verification
- full testDebugUnitTest suite passed
- lintDebug passed for API 19

Performance follow-up to #54.