### PR TITLE
Add M4B audiobook compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,7 @@ $RECYCLE.BIN/
 !/SOURCE_SHA256SUMS.txt
 !/docs/
 /docs/*
+!/docs/FORMAT_SUPPORT_MATRIX.md
 !/docs/skins/
 !/theme-studio/
 /theme-studio/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added `.m4b` audiobook indexing and AAC/ALAC playback through the existing FFmpeg MOV/MP4 path.
+
 ## 2.5 — FM radio and unified search
 
 - Added FM Radio support for the built-in MediaTek MT6627 tuner.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The diagnostics log is especially helpful because many playback, audio-effect, B
 
 - Browse local music by **Songs, Albums, Artists, Genres, Years, Folders, Playlists, Favorites, and Recently Played**.
 - Keep your place in **Audiobooks**, which are grouped by folder and resume at the minute you stopped.
-- Decode every advertised format through one pinned FFmpeg engine, including MP3, AAC/M4A, ALAC/M4A, FLAC, WAV/PCM, AIFF/PCM, Ogg Vorbis, and Opus.
+- Decode every advertised format through one pinned FFmpeg engine, including MP3, AAC/M4A/M4B, ALAC/M4A/M4B, FLAC, WAV/PCM, AIFF/PCM, Ogg Vorbis, and Opus.
 - Play individual tracks, selected batches, or complete collections and manage an explicit Up Next queue with Play Next, reordering, and removal.
 - Use repeat-one/repeat-all, configurable seeking, playback resume, gapless transitions, crossfade, and resume fades.
 - Set a sleep timer for 15, 30, or 60 minutes, or stop at the end of the current track, album, or queue.
@@ -208,7 +208,7 @@ Every playable format uses the same pinned FFmpeg engine. The scanner, playback 
 | --- | --- | --- |
 | `.mp3` | MP3 | Playable |
 | `.aac` | ADTS AAC-LC | Playable |
-| `.m4a`, `.m4r` | AAC-LC or ALAC in MOV/MP4 | Playable |
+| `.m4a`, `.m4b`, `.m4r` | AAC-LC or ALAC in MOV/MP4 | Playable |
 | `.flac` | FLAC | Playable |
 | `.wav`, `.wave` | Allowlisted integer/float PCM | Playable |
 | `.ogg`, `.oga` | Vorbis or Opus | Playable |

--- a/app/src/main/kotlin/com/schulzcode/y2player/core/model/Track.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/core/model/Track.kt
@@ -326,7 +326,7 @@ object AudioCodecSupport {
     )
 
     internal val SUPPORTED_EXTENSIONS = setOf(
-        "mp3", "m4a", "m4r", "alac", "aac", "flac",
+        "mp3", "m4a", "m4b", "m4r", "alac", "aac", "flac",
         "wav", "wave", "ogg", "oga", "opus", "aif", "aiff", "aifc"
     )
 

--- a/app/src/main/kotlin/com/schulzcode/y2player/library/LibraryScanner.kt
+++ b/app/src/main/kotlin/com/schulzcode/y2player/library/LibraryScanner.kt
@@ -316,7 +316,7 @@ class LibraryScanner(private val metadataReader: MetadataReader = MetadataReader
         val PLAYLIST_EXTENSIONS = setOf("m3u", "m3u8")
         val SUPPORTED_EXTENSIONS = setOf(
             "mp3", "flac", "wav", "wave", "ogg", "oga", "opus",
-            "m4a", "m4r", "aac", "alac", "aif", "aiff", "aifc"
+            "m4a", "m4b", "m4r", "aac", "alac", "aif", "aiff", "aifc"
         )
     }
 }

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/model/AudioCodecSupportTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/model/AudioCodecSupportTest.kt
@@ -7,6 +7,9 @@ class AudioCodecSupportTest {
     @Test fun alacAndAacInTheSameContainerAreSupported() {
         assertEquals(CodecSupport.SUPPORTED, AudioCodecSupport.of("audio/mp4a-latm", "m4a"))
         assertEquals(CodecSupport.SUPPORTED, AudioCodecSupport.of("audio/alac", "m4a"))
+        assertEquals(CodecSupport.SUPPORTED, AudioCodecSupport.of("audio/mp4a-latm", "m4b"))
+        assertEquals(CodecSupport.SUPPORTED, AudioCodecSupport.of("audio/alac", "m4b"))
+        assertEquals(CodecSupport.SUPPORTED, AudioCodecSupport.of(null, "m4b"))
     }
 
     @Test fun vorbisAndOpusAreBothPlayableFromAnOggContainer() {

--- a/app/src/test/kotlin/com/schulzcode/y2player/core/model/FfmpegBuildCapabilitiesTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/core/model/FfmpegBuildCapabilitiesTest.kt
@@ -71,6 +71,14 @@ class FfmpegBuildCapabilitiesTest {
         assertTrue("pcm_s16be" in AudioCodecSupport.DECODERS)
     }
 
+    @Test fun m4bIsReachableThroughEveryLayer() {
+        assertTrue("scanner must index .m4b", "m4b" in LibraryScanner.SUPPORTED_EXTENSIONS)
+        assertEquals(CodecSupport.SUPPORTED, AudioCodecSupport.of(null, "m4b"))
+        assertTrue("mov demuxer", "mov" in AudioCodecSupport.DEMUXERS)
+        assertTrue("aac decoder", "aac" in AudioCodecSupport.DECODERS)
+        assertTrue("alac decoder", "alac" in AudioCodecSupport.DECODERS)
+    }
+
     private fun flagValues(flag: String): Set<String> {
         val script = buildScript().readText()
         val match = Regex("--$flag=([A-Za-z0-9_,]+)").find(script)

--- a/app/src/test/kotlin/com/schulzcode/y2player/library/LibraryScannerTest.kt
+++ b/app/src/test/kotlin/com/schulzcode/y2player/library/LibraryScannerTest.kt
@@ -85,6 +85,23 @@ class LibraryScannerTest {
         } finally { root.deleteRecursively() }
     }
 
+    @Test fun m4bAudiobooksAreIndexedCaseInsensitively() {
+        val root = File(System.getProperty("java.io.tmpdir"), "y2-m4b-${System.nanoTime()}")
+        val book = File(root, "Audiobooks/Test Book").apply { mkdirs() }
+        try {
+            val source = File(book, "Complete Book.M4B").apply { writeBytes(ByteArray(4_096) { 1 }) }
+            val batches = ArrayList<ScannedFile>()
+            val outcome = scanner().scan(
+                StorageRoot("internal", root), { emptyMap() }, ScanCancellation(), { batches += it }, { _, _ -> }
+            )
+
+            assertTrue(outcome.complete)
+            assertEquals(1, outcome.processedFiles)
+            assertEquals(source.absolutePath, batches.single().absolutePath)
+            assertTrue(batches.single().changedDraft?.relativePath?.endsWith("Complete Book.M4B") == true)
+        } finally { root.deleteRecursively() }
+    }
+
     private fun volumeOf(count: Int, bytes: Int = 1_024): File {
         val root = File(System.getProperty("java.io.tmpdir"), "y2-cost-${System.nanoTime()}")
         File(root, "Music").apply { mkdirs() }.let { dir ->

--- a/docs/FORMAT_SUPPORT_MATRIX.md
+++ b/docs/FORMAT_SUPPORT_MATRIX.md
@@ -1,0 +1,40 @@
+# Format support matrix
+
+All advertised formats use the same FFmpeg decoder and AudioTrack lifecycle.
+There is no platform-decoder fallback.
+
+| Extension/container | Codec | Status |
+| --- | --- | --- |
+| `.mp3` | MPEG Layer III | Enabled |
+| `.aac` | AAC/ADTS | Enabled |
+| `.m4a`, `.m4b`, `.m4r` | AAC in MOV/MP4 | Enabled |
+| `.m4a`, `.m4b`, `.m4r` | ALAC in MOV/MP4 | Enabled |
+| `.flac` | FLAC | Enabled |
+| `.wav`, `.wave` | Allowlisted integer/float PCM | Enabled |
+| `.ogg`, `.oga` | Vorbis | Enabled |
+| `.opus`, `.ogg`, `.oga` | Opus | Enabled |
+| `.aif`, `.aiff`, `.aifc` | Allowlisted AIFF PCM | Enabled |
+| WMA, APE, MP2, AMR, WavPack, AC-3, MKA | Various | Not enabled |
+| DSF/DFF/native DSD | DSD | Not enabled and no verified output path |
+
+The library scanner indexes only the enabled extension set. Metadata for every
+indexed format comes from FFmpeg. The build also carries the ASF demuxer so the
+same metadata API can inspect WMA containers, but WMA remains unadvertised and
+unplayable because no WMA decoder is enabled.
+
+Embedded chapter metadata in an M4B does not prevent indexing or playback. The
+current audiobook model presents one physical file as one playable item; it does
+not expose embedded chapter boundaries as separate chapter rows.
+
+There is no runtime format probe: support is a build property checked against
+the native configure allowlists by unit tests. Database migration version 9
+clears old framework-specific playback failures and probe rows; version 10 drops
+the obsolete probe table. Version 11 stores the unified FFmpeg metadata record
+and schedules one refresh of existing library rows.
+
+All formats decode through the same 44.1 kHz stereo float32 internal path.
+Sources at other rates or layouts are converted by `libswresample`; application
+gain, ReplayGain, balance, fades, ducking, and crossfade retain float precision.
+The final AudioTrack output remains 44.1 kHz stereo PCM16 because that is the
+only normal primary format verified in the stock Y2 audio policy. This is not a
+claim of bit-perfect or high-rate hardware output.

--- a/tools/media/compare-results.py
+++ b/tools/media/compare-results.py
@@ -118,7 +118,7 @@ def compare(manifest: dict[str, Any], actual: dict[str, Any]) -> dict[str, Any]:
 
         should_store = Path(fixture["path"]).suffix.lower() in {
             ".mp3", ".flac", ".wav", ".wave", ".ogg", ".oga", ".opus",
-            ".m4a", ".m4r", ".aac", ".alac", ".aif", ".aiff", ".aifc",
+            ".m4a", ".m4b", ".m4r", ".aac", ".alac", ".aif", ".aiff", ".aifc",
         } and fixture["sizeBytes"] > 0
         if should_store and actual.get("scan") is not None and track is None:
             problems.append("scanner/database row missing")

--- a/tools/media/generate-corpus.py
+++ b/tools/media/generate-corpus.py
@@ -91,6 +91,12 @@ FORMATS: dict[str, FormatDefinition] = {
         "stream",
         frozenset(set(FULL_TAGS) - {"replaygain_track_gain", "replaygain_track_peak", "replaygain_album_gain", "replaygain_album_peak"}),
     ),
+    "m4b_aac": FormatDefinition(
+        "m4b_aac", ".m4b", "aac", "mov,mp4,m4a,3gp,3g2,mj2",
+        ("-c:a", "aac", "-b:a", "192k"),
+        "stream",
+        frozenset(set(FULL_TAGS) - {"replaygain_track_gain", "replaygain_track_peak", "replaygain_album_gain", "replaygain_album_peak"}),
+    ),
     "adts_aac": FormatDefinition(
         "adts_aac", ".aac", "aac", "aac", ("-c:a", "aac", "-b:a", "128k", "-f", "adts"), "none",
         frozenset(),


### PR DESCRIPTION
## Summary

- index `.m4b` audiobook files case-insensitively
- recognize AAC and ALAC M4B content through the existing FFmpeg MOV/MP4 path
- extend scanner/capability regression tests and the deterministic media corpus
- document that embedded chapter metadata is playable, while one physical M4B remains one audiobook item in the current UI

## Validation

- `ANDROID_SDK_ROOT=/opt/android-sdk bash ./gradlew -PallowStaleNative=true testDebugUnitTest lintDebug`
- generated the complete 79-fixture media corpus, including M4B
- generated and decoded an AAC M4B with two embedded chapters
- generated and decoded an ALAC M4B

Fixes #112